### PR TITLE
Create a schema for the API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ meilisearch-sdk = "0.1.4"
 serde_json = "1.0"
 serde = {version="1.0", features=["derive"]}
 chrono = { version = "0.4", features = ["serde"] }
+rand = "0.7"
 
 dotenv = "0.15"
 log = "0.4.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ meilisearch-sdk = "0.1.4"
 
 serde_json = "1.0"
 serde = {version="1.0", features=["derive"]}
+chrono = { version = "0.4", features = ["serde"] }
 
 dotenv = "0.15"
 log = "0.4.8"

--- a/src/models/error.rs
+++ b/src/models/error.rs
@@ -1,4 +1,6 @@
 use serde::{Deserialize, Serialize};
+
+/// An error returned by the API
 #[derive(Serialize, Deserialize)]
 pub struct ApiError<'a> {
     pub error: &'a str,

--- a/src/models/ids.rs
+++ b/src/models/ids.rs
@@ -1,29 +1,7 @@
-use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-/// The ID of a specific mod, encoded as base62 for usage in the API
-#[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(from = "Base62Id")]
-#[serde(into = "Base62Id")]
-pub struct ModId(pub u64);
-
-/// The ID of a specific user, encoded as base62 for usage in the API
-#[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(from = "Base62Id")]
-#[serde(into = "Base62Id")]
-pub struct UserId(pub u64);
-
-/// The ID of a specific version of a mod
-#[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(from = "Base62Id")]
-#[serde(into = "Base62Id")]
-pub struct VersionId(pub u64);
-
-/// The ID of a team
-#[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(from = "Base62Id")]
-#[serde(into = "Base62Id")]
-pub struct TeamId(pub u64);
+pub use super::mods::{ModId, VersionId};
+pub use super::teams::{UserId, TeamId};
 
 /// An ID encoded as base62 for use in the API.
 ///

--- a/src/models/ids.rs
+++ b/src/models/ids.rs
@@ -1,0 +1,134 @@
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(from = "Base62Id")]
+#[serde(into = "Base62Id")]
+pub struct ModId(pub u64);
+
+#[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(from = "Base62Id")]
+#[serde(into = "Base62Id")]
+pub struct UserId(pub u64);
+
+#[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(from = "Base62Id")]
+#[serde(into = "Base62Id")]
+pub struct VersionId(pub u64);
+
+#[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(from = "Base62Id")]
+#[serde(into = "Base62Id")]
+pub struct TeamId(pub u64);
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct Base62Id(pub u64);
+
+#[derive(Error, Debug)]
+pub enum EncodingError {
+    #[error("Invalid base62 encoding")]
+    InvalidBase62(char),
+}
+
+macro_rules! from_base62id {
+    ($($struct:ty, $con:expr;)+) => {
+        $(
+            impl From<Base62Id> for $struct {
+                fn from(id: Base62Id) -> $struct {
+                    $con(id.0)
+                }
+            }
+            impl From<$struct> for Base62Id {
+                fn from(id: $struct) -> Base62Id {
+                    Base62Id(id.0)
+                }
+            }
+        )+
+    };
+}
+
+from_base62id! {
+    ModId, ModId;
+    UserId, UserId;
+    VersionId, VersionId;
+    TeamId, TeamId;
+}
+
+mod base62_impl {
+    use serde::de::{self, Deserializer, Visitor};
+    use serde::ser::Serializer;
+    use serde::{Deserialize, Serialize};
+
+    use super::{Base62Id, EncodingError};
+
+    impl<'de> Deserialize<'de> for Base62Id {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            struct Base62Visitor;
+
+            impl<'de> Visitor<'de> for Base62Visitor {
+                type Value = Base62Id;
+
+                fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                    formatter.write_str("a base62 string id")
+                }
+
+                fn visit_str<E>(self, string: &str) -> Result<Base62Id, E>
+                where
+                    E: de::Error,
+                {
+                    parse_base62(string).map(Base62Id).map_err(E::custom)
+                }
+            }
+
+            deserializer.deserialize_str(Base62Visitor)
+        }
+    }
+
+    impl Serialize for Base62Id {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            serializer.serialize_str(&to_base62(self.0))
+        }
+    }
+
+    const BASE62_CHARS: [u8; 62] = [
+        b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8', b'9', b'A', b'B', b'C', b'D', b'E',
+        b'F', b'G', b'H', b'I', b'J', b'K', b'L', b'M', b'N', b'O', b'P', b'Q', b'R', b'S', b'T',
+        b'U', b'V', b'W', b'X', b'Y', b'Z', b'a', b'b', b'c', b'd', b'e', b'f', b'g', b'h', b'i',
+        b'j', b'k', b'l', b'm', b'n', b'o', b'p', b'q', b'r', b's', b't', b'u', b'v', b'w', b'x',
+        b'y', b'z',
+    ];
+
+    fn to_base62(mut num: u64) -> String {
+        let length = (num as f64).log(62.0).ceil() as usize;
+        let mut output = String::with_capacity(length);
+
+        while num > 0 {
+            output.push(BASE62_CHARS[(num % 62) as usize] as char);
+            num /= 62;
+        }
+        output
+    }
+
+    fn parse_base62(string: &str) -> Result<u64, EncodingError> {
+        let mut num = 0;
+        for c in string.chars().rev() {
+            num *= 62;
+            if c.is_ascii_digit() {
+                num += (c as u8 - b'0') as u64;
+            } else if c.is_ascii_uppercase() {
+                num += 10 + (c as u8 - b'A') as u64;
+            } else if c.is_ascii_lowercase() {
+                num += 36 + (c as u8 - b'a') as u64;
+            } else {
+                return Err(EncodingError::InvalidBase62(c));
+            }
+        }
+        Ok(num)
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,2 +1,4 @@
 pub mod error;
+pub mod ids;
 pub mod mods;
+pub mod teams;

--- a/src/models/mods.rs
+++ b/src/models/mods.rs
@@ -1,30 +1,14 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-// TODO: use serde to parse this as base62
-#[derive(Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct ModId(pub String);
-
-// TODO: use serde to parse this as base62
-#[derive(Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct UserId(String);
-
-// TODO: what format should this be?
-#[derive(Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct VersionId(String);
-
-// TODO: permissions, role names, etc
-#[derive(Serialize, Deserialize)]
-pub struct Team {
-    users: Vec<(String, UserId)>,
-}
+use super::ids::*;
+use super::teams::Team;
 
 #[derive(Serialize, Deserialize)]
 pub struct Mod {
     pub id: ModId,
+    // TODO: send partial team structure to reduce requests, but avoid sending
+    // unnecessary info
     pub team: Team,
 
     pub title: String,
@@ -35,8 +19,9 @@ pub struct Mod {
     pub categories: Vec<String>,
     pub versions: Vec<VersionId>,
 
-    pub body_url: String,
-    pub icon_url: String,
+    pub issues_url: Option<String>,
+    pub source_url: Option<String>,
+    pub wiki_url: Option<String>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -48,6 +33,8 @@ pub struct Version {
     pub changelog_url: String,
     pub date_published: DateTime<Utc>,
     pub downloads: u32,
+    pub version_type: VersionType,
+
     pub files: Vec<VersionFile>,
     pub dependencies: Vec<ModId>,
     pub game_versions: Vec<GameVersion>,
@@ -59,6 +46,13 @@ pub struct VersionFile {
     // TODO: hashing algorithm?
     pub hash: String,
     pub url: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum VersionType {
+    Release,
+    Beta,
+    Alpha,
 }
 
 /// A specific version of Minecraft

--- a/src/models/mods.rs
+++ b/src/models/mods.rs
@@ -1,7 +1,7 @@
-use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
 use super::ids::Base62Id;
 use super::teams::Team;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 
 /// The ID of a specific mod, encoded as base62 for usage in the API
 #[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/models/mods.rs
+++ b/src/models/mods.rs
@@ -4,48 +4,85 @@ use serde::{Deserialize, Serialize};
 use super::ids::*;
 use super::teams::Team;
 
+/// A mod returned from the API
 #[derive(Serialize, Deserialize)]
 pub struct Mod {
+    /// The ID of the mod, encoded as a base62 string.
     pub id: ModId,
     // TODO: send partial team structure to reduce requests, but avoid sending
     // unnecessary info
+    /// The team of people that has ownership of this mod.
     pub team: Team,
 
+    /// The title or name of the mod.
     pub title: String,
+    /// A short description of the mod.
     pub description: String,
+    /// The date at which the mod was first published.
     pub published: DateTime<Utc>,
 
+    /// The total number of downloads the mod has had.
     pub downloads: u32,
+    /// A list of the categories that the mod is in.
     pub categories: Vec<String>,
+    /// A list of ids for versions of the mod.
     pub versions: Vec<VersionId>,
 
+    /// The latest version of the mod.
+    pub latest_version: Version,
+
+    /// An optional link to where to submit bugs or issues with the mod.
     pub issues_url: Option<String>,
+    /// An optional link to the source code for the mod.
     pub source_url: Option<String>,
+    /// An optional link to the mod's wiki page or other relevant information.
     pub wiki_url: Option<String>,
 }
 
+/// A specific version of a mod
 #[derive(Serialize, Deserialize)]
 pub struct Version {
+    /// The ID of the version, encoded as a base62 string.
     pub id: VersionId,
+    /// The ID of the mod this version is for.
     pub mod_id: ModId,
 
-    pub title: String,
-    pub changelog_url: String,
+    /// The name of this version
+    pub name: String,
+    /// A link to the changelog for this version of the mod.
+    pub changelog_url: Option<String>,
+    /// The date that this version was published.
     pub date_published: DateTime<Utc>,
+    /// The number of downloads this specific version has had.
     pub downloads: u32,
+    /// The type of the release - `Alpha`, `Beta`, or `Release`.
     pub version_type: VersionType,
 
+    /// A list of files available for download for this version.
     pub files: Vec<VersionFile>,
+    /// A list of mods that this version depends on.
     pub dependencies: Vec<ModId>,
+    /// A list of versions of Minecraft that this version of the mod supports.
     pub game_versions: Vec<GameVersion>,
 }
 
 /// A single mod file, with a url for the file and the file's hash
 #[derive(Serialize, Deserialize)]
 pub struct VersionFile {
-    // TODO: hashing algorithm?
-    pub hash: String,
+    /// A list of hashes of the file
+    pub hashes: Vec<FileHash>,
+    /// A direct link to the file for downloading it.
     pub url: String,
+}
+
+/// A hash of a mod's file
+#[derive(Serialize, Deserialize)]
+pub struct FileHash {
+    // TODO: decide specific algorithms
+    /// The hashing algorithm used for this hash; could be "md5", "sha1", etc
+    pub algorithm: String,
+    /// The file hash, using the specified algorithm
+    pub hash: String,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/src/models/mods.rs
+++ b/src/models/mods.rs
@@ -1,8 +1,19 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-
-use super::ids::*;
+use super::ids::Base62Id;
 use super::teams::Team;
+
+/// The ID of a specific mod, encoded as base62 for usage in the API
+#[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(from = "Base62Id")]
+#[serde(into = "Base62Id")]
+pub struct ModId(pub u64);
+
+/// The ID of a specific version of a mod
+#[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(from = "Base62Id")]
+#[serde(into = "Base62Id")]
+pub struct VersionId(pub u64);
 
 /// A mod returned from the API
 #[derive(Serialize, Deserialize)]

--- a/src/models/mods.rs
+++ b/src/models/mods.rs
@@ -1,4 +1,70 @@
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+
+// TODO: use serde to parse this as base62
+#[derive(Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ModId(pub String);
+
+// TODO: use serde to parse this as base62
+#[derive(Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct UserId(String);
+
+// TODO: what format should this be?
+#[derive(Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct VersionId(String);
+
+// TODO: permissions, role names, etc
+#[derive(Serialize, Deserialize)]
+pub struct Team {
+    users: Vec<(String, UserId)>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Mod {
+    pub id: ModId,
+    pub team: Team,
+
+    pub title: String,
+    pub description: String,
+    pub published: DateTime<Utc>,
+
+    pub downloads: u32,
+    pub categories: Vec<String>,
+    pub versions: Vec<VersionId>,
+
+    pub body_url: String,
+    pub icon_url: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Version {
+    pub id: VersionId,
+    pub mod_id: ModId,
+
+    pub title: String,
+    pub changelog_url: String,
+    pub date_published: DateTime<Utc>,
+    pub downloads: u32,
+    pub files: Vec<VersionFile>,
+    pub dependencies: Vec<ModId>,
+    pub game_versions: Vec<GameVersion>,
+}
+
+/// A single mod file, with a url for the file and the file's hash
+#[derive(Serialize, Deserialize)]
+pub struct VersionFile {
+    // TODO: hashing algorithm?
+    pub hash: String,
+    pub url: String,
+}
+
+/// A specific version of Minecraft
+#[derive(Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct GameVersion(pub String);
 
 #[derive(Serialize, Deserialize)]
 pub struct SearchRequest {

--- a/src/models/teams.rs
+++ b/src/models/teams.rs
@@ -1,0 +1,15 @@
+use super::ids::*;
+use serde::{Deserialize, Serialize};
+
+// TODO: permissions, role names, etc
+#[derive(Serialize, Deserialize)]
+pub struct Team {
+    id: TeamId,
+    members: Vec<TeamMember>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct TeamMember {
+    user_id: UserId,
+    name: String,
+}

--- a/src/models/teams.rs
+++ b/src/models/teams.rs
@@ -1,5 +1,17 @@
-use super::ids::*;
 use serde::{Deserialize, Serialize};
+use super::ids::Base62Id;
+
+/// The ID of a specific user, encoded as base62 for usage in the API
+#[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(from = "Base62Id")]
+#[serde(into = "Base62Id")]
+pub struct UserId(pub u64);
+
+/// The ID of a team
+#[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(from = "Base62Id")]
+#[serde(into = "Base62Id")]
+pub struct TeamId(pub u64);
 
 // TODO: permissions, role names, etc
 /// A team of users who control a mod

--- a/src/models/teams.rs
+++ b/src/models/teams.rs
@@ -2,14 +2,20 @@ use super::ids::*;
 use serde::{Deserialize, Serialize};
 
 // TODO: permissions, role names, etc
+/// A team of users who control a mod
 #[derive(Serialize, Deserialize)]
 pub struct Team {
-    id: TeamId,
-    members: Vec<TeamMember>,
+    /// The id of the team
+    pub id: TeamId,
+    /// A list of the members of the team
+    pub members: Vec<TeamMember>,
 }
 
+/// A member of a team
 #[derive(Serialize, Deserialize)]
 pub struct TeamMember {
-    user_id: UserId,
-    name: String,
+    /// The ID of the user associated with the member
+    pub user_id: UserId,
+    /// The name of the user
+    pub name: String,
 }

--- a/src/models/teams.rs
+++ b/src/models/teams.rs
@@ -1,5 +1,5 @@
-use serde::{Deserialize, Serialize};
 use super::ids::Base62Id;
+use serde::{Deserialize, Serialize};
 
 /// The ID of a specific user, encoded as base62 for usage in the API
 #[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
This adds structures for an API schema.  It currently covers mods, their versions, and some of the ids that may be used.

The `Id` structs will need custom `serde` implementations for parsing base62 (unless there's a library that deals with that).  The `Team` structure is still unfinished, and more specifics will need to be worked out for most of the structures.