### PR TITLE
Fix sqlx id structs and update sqlx to the latest master (0.4.0-beta.1)

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
 DEBUG=true
+RUST_LOG=info,sqlx::query=warn
 
 CDN_URL=cdn.modrinth.com
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1519,50 +1519,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
-name = "phf"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
-dependencies = [
- "phf_macros",
- "phf_shared",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
-dependencies = [
- "phf_shared",
- "rand",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6fde18ff429ffc8fe78e2bf7f8b7a5a5a6e2a8b58bc5a9ac69198bbda9189c"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
 name = "pin-project"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1653,7 +1609,6 @@ dependencies = [
  "rand_chacha",
  "rand_core",
  "rand_hc",
- "rand_pcg",
 ]
 
 [[package]]
@@ -1680,15 +1635,6 @@ name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core",
 ]
@@ -1939,12 +1885,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "siphasher"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8f3741c7372e75519bd9346068370c9cdaabcc1f9599cbcf2a2719352286b7"
-
-[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1981,8 +1921,8 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.4.0-pre"
-source = "git+https://github.com/launchbadge/sqlx/#41261862d3537bd386149b4bf40d3a9517f73205"
+version = "0.4.0-beta.1"
+source = "git+https://github.com/launchbadge/sqlx/#94413bd830422ecd127efeeb92a5fbca89a5523d"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -1990,8 +1930,8 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.4.0-pre"
-source = "git+https://github.com/launchbadge/sqlx/#41261862d3537bd386149b4bf40d3a9517f73205"
+version = "0.4.0-beta.1"
+source = "git+https://github.com/launchbadge/sqlx/#94413bd830422ecd127efeeb92a5fbca89a5523d"
 dependencies = [
  "atoi",
  "base64 0.12.3",
@@ -2018,7 +1958,6 @@ dependencies = [
  "once_cell",
  "parking_lot 0.11.0",
  "percent-encoding",
- "phf",
  "rand",
  "serde",
  "sha-1",
@@ -2034,8 +1973,8 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.4.0-pre"
-source = "git+https://github.com/launchbadge/sqlx/#41261862d3537bd386149b4bf40d3a9517f73205"
+version = "0.4.0-beta.1"
+source = "git+https://github.com/launchbadge/sqlx/#94413bd830422ecd127efeeb92a5fbca89a5523d"
 dependencies = [
  "dotenv",
  "either",
@@ -2055,8 +1994,8 @@ dependencies = [
 
 [[package]]
 name = "sqlx-rt"
-version = "0.1.0-pre"
-source = "git+https://github.com/launchbadge/sqlx/#41261862d3537bd386149b4bf40d3a9517f73205"
+version = "0.1.1"
+source = "git+https://github.com/launchbadge/sqlx/#94413bd830422ecd127efeeb92a5fbca89a5523d"
 dependencies = [
  "actix-rt",
  "actix-threadpool",

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -1,5 +1,47 @@
 {
   "db": "PostgreSQL",
+  "1524c0462be70077736ac70fcd037fbf75651456b692e2ce40fa2e3fc8123984": {
+    "query": "\n                    SELECT hashes.algorithm, hashes.hash FROM hashes\n                    WHERE hashes.file_id = $1\n                    ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "algorithm",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 1,
+          "name": "hash",
+          "type_info": "Bytea"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8"
+        ]
+      },
+      "nullable": [
+        false,
+        false
+      ]
+    }
+  },
+  "15b2a2f1bbbbab4f1d99e5e428b2ffba77c83814b936fa6e10e2703b207f6e9a": {
+    "query": "\n                INSERT INTO team_members (id, team_id, user_id, member_name, role)\n                VALUES ($1, $2, $3, $4, $5)\n                ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Int8",
+          "Int8",
+          "Int8",
+          "Varchar",
+          "Varchar"
+        ]
+      },
+      "nullable": []
+    }
+  },
   "1ffce9b2d5c9fa6c8b9abce4bad9f9419c44ad6367b7463b979c91b9b5b4fea1": {
     "query": "SELECT EXISTS(SELECT 1 FROM versions WHERE id=$1)",
     "describe": {
@@ -17,6 +59,75 @@
       },
       "nullable": [
         null
+      ]
+    }
+  },
+  "29e657d26f0fb24a766f5b5eb6a94d01d1616884d8ca10e91536e974d5b585a6": {
+    "query": "\n                INSERT INTO loaders_versions (loader_id, version_id)\n                VALUES ($1, $2)\n                ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Int4",
+          "Int8"
+        ]
+      },
+      "nullable": []
+    }
+  },
+  "35272854c6aeb743218e73ccf6f34427ab72f25492dfa752f87a50e3da7204c5": {
+    "query": "\n            SELECT v.mod_id, v.name, v.version_number,\n                v.changelog_url, v.date_published, v.downloads,\n                release_channels.channel\n            FROM versions v\n            INNER JOIN release_channels ON v.release_channel = release_channels.id\n            WHERE v.id = $1\n            ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "mod_id",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 1,
+          "name": "name",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 2,
+          "name": "version_number",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 3,
+          "name": "changelog_url",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 4,
+          "name": "date_published",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 5,
+          "name": "downloads",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 6,
+          "name": "channel",
+          "type_info": "Varchar"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8"
+        ]
+      },
+      "nullable": [
+        true,
+        false,
+        false,
+        true,
+        false,
+        false,
+        true
       ]
     }
   },
@@ -40,6 +151,228 @@
       ]
     }
   },
+  "560c3ba57c965c3ebdbe393b062da8a30a8a7116a9bace2aa7de2e8431fe0bc7": {
+    "query": "\n                INSERT INTO mods_categories (joining_mod_id, joining_category_id)\n                VALUES ($1, $2)\n                ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Int8",
+          "Int4"
+        ]
+      },
+      "nullable": []
+    }
+  },
+  "59cf9d085593887595ea45246291f2cd64fc6677d551e96bdb60c09ff1eebf99": {
+    "query": "\n                SELECT files.id, files.url, files.filename FROM files\n                WHERE files.version_id = $1\n                ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 1,
+          "name": "url",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 2,
+          "name": "filename",
+          "type_info": "Varchar"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        false
+      ]
+    }
+  },
+  "5aaae159c75c9385f4d969338bce509852d4b3e3ae9d4c4e366055b5b499b19a": {
+    "query": "\n            SELECT v.mod_id, v.name, v.version_number,\n                v.changelog_url, v.date_published, v.downloads,\n                v.release_channel\n            FROM versions v\n            WHERE v.id = $1\n            ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "mod_id",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 1,
+          "name": "name",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 2,
+          "name": "version_number",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 3,
+          "name": "changelog_url",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 4,
+          "name": "date_published",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 5,
+          "name": "downloads",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 6,
+          "name": "release_channel",
+          "type_info": "Int4"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8"
+        ]
+      },
+      "nullable": [
+        true,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false
+      ]
+    }
+  },
+  "96d7b2c8b7b69fc370bb1a2d4a449f972eb3893dad5d6c59e498663cfc93a5c3": {
+    "query": "\n            SELECT title, description, downloads,\n                   icon_url, body_url, published,\n                   issues_url, source_url, wiki_url,\n                   team_id\n            FROM mods\n            WHERE id = $1\n            ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "title",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 1,
+          "name": "description",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 2,
+          "name": "downloads",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 3,
+          "name": "icon_url",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 4,
+          "name": "body_url",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 5,
+          "name": "published",
+          "type_info": "Timestamptz"
+        },
+        {
+          "ordinal": 6,
+          "name": "issues_url",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 7,
+          "name": "source_url",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 8,
+          "name": "wiki_url",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 9,
+          "name": "team_id",
+          "type_info": "Int8"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        true,
+        true,
+        true,
+        false
+      ]
+    }
+  },
+  "b9399840dbbf807a03d69b7fcb3bd479ef20920ab1e3c91706a1c2c7089f48e7": {
+    "query": "\n            INSERT INTO teams (id)\n            VALUES ($1)\n            ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Int8"
+        ]
+      },
+      "nullable": []
+    }
+  },
+  "b96ab39ab9624bfcdc8675107544307af9892504c4cbc40e4e7c40a1e4e83e14": {
+    "query": "\n                INSERT INTO game_versions_versions (game_version_id, joining_version_id)\n                VALUES ($1, $2)\n                ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Int4",
+          "Int8"
+        ]
+      },
+      "nullable": []
+    }
+  },
+  "bdc13b0000987fe08351751fed4f388856eb5c022bb27c2919dd72d4409c2412": {
+    "query": "\n            INSERT INTO mods (\n                id, team_id, title, description, body_url,\n                published, downloads, icon_url, issues_url,\n                source_url, wiki_url\n            )\n            VALUES (\n                $1, $2, $3, $4, $5,\n                $6, $7, $8, $9,\n                $10, $11\n            )\n            ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Int8",
+          "Int8",
+          "Varchar",
+          "Varchar",
+          "Varchar",
+          "Timestamptz",
+          "Int4",
+          "Varchar",
+          "Varchar",
+          "Varchar",
+          "Varchar"
+        ]
+      },
+      "nullable": []
+    }
+  },
   "c0899dcff4d7bc1ba3e953e5099210316bff2f98e6ab77ba84bc612eac4bce0a": {
     "query": "\n                SELECT gv.version FROM versions\n                    INNER JOIN game_versions_versions gvv ON gvv.joining_version_id=versions.id\n                    INNER JOIN game_versions gv ON gvv.game_version_id=gv.id\n                WHERE versions.mod_id = $1\n                ",
     "describe": {
@@ -58,6 +391,19 @@
       "nullable": [
         false
       ]
+    }
+  },
+  "c82eb1b059b62444ab1d17e5a0bd7ef8acea4b05c6f3576c07d20c4ca7635a11": {
+    "query": "\n                INSERT INTO dependencies (dependent_id, dependency_id)\n                VALUES ($1, $2)\n                ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Int8",
+          "Int8"
+        ]
+      },
+      "nullable": []
     }
   },
   "ccd913bb2f3006ffe881ce2fc4ef1e721d18fe2eed6ac62627046c955129610c": {
@@ -100,6 +446,20 @@
       ]
     }
   },
+  "d67e6c185460a17b65c0dc01be0f436b87acc79fc56513f1c5c4c99e9b9cb283": {
+    "query": "\n                    INSERT INTO hashes (file_id, algorithm, hash)\n                    VALUES ($1, $2, $3)\n                    ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Int8",
+          "Varchar",
+          "Bytea"
+        ]
+      },
+      "nullable": []
+    }
+  },
   "e7d0a64a08df6783c942f2fcadd94dd45f8d96ad3d3736e52ce90f68d396cdab": {
     "query": "SELECT EXISTS(SELECT 1 FROM team_members WHERE id=$1)",
     "describe": {
@@ -138,6 +498,25 @@
       "nullable": [
         null
       ]
+    }
+  },
+  "eaea3f606f926d7e1fc51a9798ce3c6448f0f02d55ce48bb38e84dc1bdced740": {
+    "query": "\n            INSERT INTO versions (\n                id, mod_id, name, version_number,\n                changelog_url, date_published,\n                downloads, release_channel\n            )\n            VALUES (\n                $1, $2, $3, $4,\n                $5, $6,\n                $7, $8\n            )\n            ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Int8",
+          "Int8",
+          "Varchar",
+          "Varchar",
+          "Varchar",
+          "Timestamptz",
+          "Int4",
+          "Int4"
+        ]
+      },
+      "nullable": []
     }
   },
   "efe1bc80203f608226fa33e44654b681cc4430cec63bf7cf09b5281ff8c1c437": {
@@ -192,6 +571,81 @@
         false,
         false
       ]
+    }
+  },
+  "f0dd4e10e7c5c4c27ee84be6010919a1b23cb9438ff869c1902849874c75a4af": {
+    "query": "\n                SELECT loaders.loader FROM loaders\n                INNER JOIN loaders_versions ON loaders.id = loaders_versions.loader_id\n                WHERE loaders_versions.version_id = $1\n                ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "loader",
+          "type_info": "Varchar"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8"
+        ]
+      },
+      "nullable": [
+        false
+      ]
+    }
+  },
+  "f80ca292323952d10dbd26d3453ced5c12bdd1b71dcd3cb3ade4c7d4dc3590f6": {
+    "query": "\n                SELECT gv.version FROM game_versions_versions gvv\n                INNER JOIN game_versions gv ON gvv.game_version_id=gv.id\n                WHERE gvv.joining_version_id = $1\n                ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "version",
+          "type_info": "Varchar"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8"
+        ]
+      },
+      "nullable": [
+        false
+      ]
+    }
+  },
+  "fb6178b27856ff583039a974173efe5d6be4e347b6cc1d4904cf750a40d1b77f": {
+    "query": "\n            SELECT dependency_id id FROM dependencies\n            WHERE dependent_id = $1\n            ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int8"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8"
+        ]
+      },
+      "nullable": [
+        false
+      ]
+    }
+  },
+  "fc4675de31f0256f43ff2033115f3dac603e05d400e26ac4d852929f37f5b74d": {
+    "query": "\n                INSERT INTO files (id, version_id, url, filename)\n                VALUES ($1, $2, $3, $4)\n                ",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Int8",
+          "Int8",
+          "Varchar",
+          "Varchar"
+        ]
+      },
+      "nullable": []
     }
   }
 }

--- a/src/database/models/ids.rs
+++ b/src/database/models/ids.rs
@@ -73,28 +73,38 @@ generate_ids!(
 );
 
 #[derive(Copy, Clone, Debug, Type)]
+#[sqlx(transparent)]
 pub struct UserId(pub i64);
 
 #[derive(Copy, Clone, Debug, Type)]
+#[sqlx(transparent)]
 pub struct TeamId(pub i64);
 #[derive(Copy, Clone, Debug, Type)]
+#[sqlx(transparent)]
 pub struct TeamMemberId(pub i64);
 
 #[derive(Copy, Clone, Debug, Type)]
+#[sqlx(transparent)]
 pub struct ModId(pub i64);
 
 #[derive(Copy, Clone, Debug, Type)]
+#[sqlx(transparent)]
 pub struct VersionId(pub i64);
 #[derive(Copy, Clone, Debug, Type)]
-pub struct ChannelId(pub i64);
+#[sqlx(transparent)]
+pub struct ChannelId(pub i32);
 #[derive(Copy, Clone, Debug, Type)]
+#[sqlx(transparent)]
 pub struct GameVersionId(pub i32);
 #[derive(Copy, Clone, Debug, Type)]
+#[sqlx(transparent)]
 pub struct LoaderId(pub i32);
 #[derive(Copy, Clone, Debug, Type)]
+#[sqlx(transparent)]
 pub struct CategoryId(pub i32);
 
 #[derive(Copy, Clone, Debug, Type)]
+#[sqlx(transparent)]
 pub struct FileId(pub i64);
 
 use crate::models::ids;

--- a/src/database/models/mod_item.rs
+++ b/src/database/models/mod_item.rs
@@ -40,14 +40,14 @@ impl ModBuilder {
         }
 
         for category in self.categories {
-            sqlx::query(
+            sqlx::query!(
                 "
-                INSERT INTO mod_categories (joining_mod_id, joining_category_id)
+                INSERT INTO mods_categories (joining_mod_id, joining_category_id)
                 VALUES ($1, $2)
                 ",
+                self.mod_id as ModId,
+                category as CategoryId,
             )
-            .bind(self.mod_id)
-            .bind(category)
             .execute(&mut *transaction)
             .await?;
         }
@@ -75,7 +75,7 @@ impl Mod {
         &self,
         transaction: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     ) -> Result<(), sqlx::error::Error> {
-        sqlx::query(
+        sqlx::query!(
             "
             INSERT INTO mods (
                 id, team_id, title, description, body_url,
@@ -88,18 +88,18 @@ impl Mod {
                 $10, $11
             )
             ",
+            self.id as ModId,
+            self.team_id as TeamId,
+            &self.title,
+            &self.description,
+            &self.body_url,
+            self.published,
+            self.downloads,
+            self.icon_url.as_ref(),
+            self.issues_url.as_ref(),
+            self.source_url.as_ref(),
+            self.wiki_url.as_ref(),
         )
-        .bind(self.id)
-        .bind(self.team_id)
-        .bind(&self.title)
-        .bind(&self.description)
-        .bind(&self.body_url)
-        .bind(self.published)
-        .bind(self.downloads)
-        .bind(self.icon_url.as_ref())
-        .bind(self.issues_url.as_ref())
-        .bind(self.source_url.as_ref())
-        .bind(self.wiki_url.as_ref())
         .execute(&mut *transaction)
         .await?;
 

--- a/src/database/models/team_item.rs
+++ b/src/database/models/team_item.rs
@@ -18,13 +18,13 @@ impl TeamBuilder {
 
         let team = Team { id: team_id };
 
-        sqlx::query(
+        sqlx::query!(
             "
             INSERT INTO teams (id)
             VALUES ($1)
             ",
+            team.id as TeamId,
         )
-        .bind(team.id)
         .execute(&mut *transaction)
         .await?;
 
@@ -38,17 +38,17 @@ impl TeamBuilder {
                 role: member.role,
             };
 
-            sqlx::query(
+            sqlx::query!(
                 "
-                INSERT INTO team_members (id, team_id, user_id, name, role)
-                VALUES ($1, $2)
+                INSERT INTO team_members (id, team_id, user_id, member_name, role)
+                VALUES ($1, $2, $3, $4, $5)
                 ",
+                team_member.id as TeamMemberId,
+                team_member.team_id as TeamId,
+                team_member.user_id as UserId,
+                team_member.name,
+                team_member.role,
             )
-            .bind(team_member.id)
-            .bind(team_member.team_id)
-            .bind(team_member.user_id)
-            .bind(team_member.name)
-            .bind(team_member.role)
             .execute(&mut *transaction)
             .await?;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,8 +15,8 @@ mod search;
 
 #[actix_rt::main]
 async fn main() -> std::io::Result<()> {
-    env_logger::from_env(Env::default().default_filter_or("info")).init();
     dotenv::dotenv().ok();
+    env_logger::from_env(Env::default().default_filter_or("info")).init();
 
     check_env_vars();
 
@@ -145,6 +145,7 @@ async fn main() -> std::io::Result<()> {
             .wrap(Logger::new("%a %{User-Agent}i"))
             .data(pool.clone())
             .data(file_host.clone())
+            .data(indexing_queue.clone())
             .service(routes::index_get)
             .service(routes::mod_search)
             .service(routes::mod_create)

--- a/src/routes/mod_creation.rs
+++ b/src/routes/mod_creation.rs
@@ -261,9 +261,9 @@ async fn mod_create_inner(
 
                 // TODO: do a real lookup for the channels
                 let release_channel = match version_data.release_channel {
-                    VersionType::Release => models::ChannelId(0),
-                    VersionType::Beta => models::ChannelId(2),
-                    VersionType::Alpha => models::ChannelId(4),
+                    VersionType::Release => models::ChannelId(1),
+                    VersionType::Beta => models::ChannelId(3),
+                    VersionType::Alpha => models::ChannelId(5),
                 };
 
                 let version = models::version_item::VersionBuilder {


### PR DESCRIPTION
This updates sqlx, so the query macro no longer breaks the type recursion limit, and modifies the Id structs so that sqlx supports them better.  If sqlx gives you a type error when using an id as a parameter to the query macro (it will say it expected an i32 or i64), add `as SomethingId` with the type of the id after it. 