### PR TITLE
Faceted search based on mod host (curseforge/modrinth)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,6 +904,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
 
 [[package]]
+name = "gumdrop"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46571f5d540478cf70d2a42dd0d6d8e9f4b9cc7531544b93311e657b86568a0b"
+dependencies = [
+ "gumdrop_derive",
+]
+
+[[package]]
+name = "gumdrop_derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915ef07c710d84733522461de2a734d4d62a3fd39a4d4f404c2f385ef8618d05"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "h2"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1137,6 +1157,7 @@ dependencies = [
  "env_logger",
  "futures",
  "futures-timer",
+ "gumdrop",
  "log",
  "meilisearch-sdk",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ serde = { version = "1.0", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
 rand = "0.7"
 
+gumdrop = "0.8"
 dotenv = "0.15"
 log = "0.4.8"
 env_logger = "0.7.1"

--- a/src/routes/mod_creation.rs
+++ b/src/routes/mod_creation.rs
@@ -11,6 +11,7 @@ use actix_web::{post, HttpResponse};
 use futures::stream::StreamExt;
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgPool;
+use std::borrow::Cow;
 use std::sync::Arc;
 use thiserror::Error;
 
@@ -416,7 +417,8 @@ async fn mod_create_inner(
         // TODO: store and return modified time
         date_modified: formatted,
         modified_timestamp: timestamp,
-        empty: std::borrow::Cow::Borrowed("{}{}{}"),
+        host: Cow::Borrowed("modrinth"),
+        empty: Cow::Borrowed("{}{}{}"),
     };
 
     indexing_queue.add(index_mod);

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -13,9 +13,9 @@ impl Scheduler {
         }
     }
 
-    pub fn run<F, R>(&mut self, interval: std::time::Duration, task: F)
+    pub fn run<F, R>(&mut self, interval: std::time::Duration, mut task: F)
     where
-        F: Fn() -> R + Send + 'static,
+        F: FnMut() -> R + Send + 'static,
         R: std::future::Future<Output = ()> + Send + 'static,
     {
         let future = time::interval(interval).for_each_concurrent(2, move |_| task());

--- a/src/search/indexing/curseforge_import.rs
+++ b/src/search/indexing/curseforge_import.rs
@@ -2,6 +2,7 @@ use super::IndexingError;
 use crate::search::UploadSearchMod;
 use log::info;
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -200,7 +201,8 @@ pub async fn index_curseforge(
             date_modified: modified.to_string(),
             modified_timestamp: modified.timestamp(),
             latest_version,
-            empty: std::borrow::Cow::Borrowed("{}{}{}"),
+            host: Cow::Borrowed("curseforge"),
+            empty: Cow::Borrowed("{}{}{}"),
         })
     }
 

--- a/src/search/indexing/local_import.rs
+++ b/src/search/indexing/local_import.rs
@@ -4,6 +4,7 @@ use log::info;
 use super::IndexingError;
 use crate::search::UploadSearchMod;
 use sqlx::postgres::PgPool;
+use std::borrow::Cow;
 
 pub async fn index_local(pool: PgPool) -> Result<Vec<UploadSearchMod>, IndexingError> {
     info!("Indexing local mods!");
@@ -71,7 +72,8 @@ pub async fn index_local(pool: PgPool) -> Result<Vec<UploadSearchMod>, IndexingE
                 date_modified: formatted,
                 modified_timestamp: timestamp,
                 latest_version: "".to_string(), // TODO: Info about latest version
-                empty: std::borrow::Cow::Borrowed("{}{}{}"),
+                host: Cow::Borrowed("modrinth"),
+                empty: Cow::Borrowed("{}{}{}"),
             });
         }
     }

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -71,6 +71,8 @@ pub struct UploadSearchMod {
     /// Unix timestamp of the last major modification
     pub modified_timestamp: i64,
 
+    pub host: Cow<'static, str>,
+
     /// Must be "{}{}{}", a hack until meilisearch supports searches
     /// with empty queries (https://github.com/meilisearch/MeiliSearch/issues/729)
     // This is a Cow to prevent unnecessary allocations for a static
@@ -96,6 +98,9 @@ pub struct ResultSearchMod {
     /// RFC 3339 formatted modification date of the mod
     pub date_modified: String,
     pub latest_version: String,
+
+    /// The host of the mod: Either `modrinth` or `curseforge`
+    pub host: String,
 }
 
 impl Document for UploadSearchMod {


### PR DESCRIPTION
This implements a meilisearch facet for the host of a mod ("curseforge" or "modrinth").  This allows for showing only mods from a specific platform, which should be useful for testing purposes - filtering out curseforge mods to test mod creation without having to reset the indices and have to reindex curseforge the next time you need it.

It's currently used by adding `facets=[["host:modrinth"]]` to the search parameters.  If you are also using category facets, you can use `facets=[["host:modrinth"],["categories:misc"]]`.

This also adds a commandline argument library (gumdrop) for dealing with indices - reseting, reconfiguring, and skipping them. I don't know which library is best for this case, but gumdrop has shorter compile times and many fewer dependencies than clap, which is why I chose it.