### PR TITLE
General cleanup: fix some bugs, some refactoring

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,7 @@
 DEBUG=true
 RUST_LOG=info,sqlx::query=warn
 
+CORS_ORIGINS='["http://localhost:3000","https://modrinth.com"]'
 CDN_URL=https://cdn.modrinth.com
 
 DATABASE_URL=postgresql://labrinth:labrinth@localhost/labrinth

--- a/migrations/20201001015631_not-null-github-avatar.sql
+++ b/migrations/20201001015631_not-null-github-avatar.sql
@@ -1,0 +1,35 @@
+
+-- Originally:
+-- ALTER TABLE users
+-- ADD COLUMN github_id bigint NOT NULL default 0,
+-- ADD COLUMN username varchar(255) NOT NULL default 'username',
+-- ADD COLUMN name varchar(255) NOT NULL default 'John Doe',
+-- ADD COLUMN email varchar(255) NULL default 'johndoe@modrinth.com',
+-- ADD COLUMN avatar_url varchar(500) NOT NULL default '...',
+-- ADD COLUMN bio varchar(160) NOT NULL default 'I make mods!',
+-- ADD COLUMN created timestamptz default CURRENT_TIMESTAMP NOT NULL
+
+-- We don't want garbage data when users are created incorrectly;
+-- we just want it to fail.
+
+ALTER TABLE users
+ALTER COLUMN github_id DROP NOT NULL;
+ALTER TABLE users
+ALTER COLUMN github_id DROP DEFAULT;
+
+ALTER TABLE users
+ALTER COLUMN avatar_url DROP NOT NULL;
+ALTER TABLE users
+ALTER COLUMN avatar_url DROP DEFAULT;
+
+ALTER TABLE users
+ALTER COLUMN username DROP DEFAULT;
+ALTER TABLE users
+ALTER COLUMN name DROP DEFAULT;
+ALTER TABLE users
+ALTER COLUMN email DROP DEFAULT;
+
+ALTER TABLE users
+ALTER COLUMN bio DROP DEFAULT;
+ALTER TABLE users
+ALTER COLUMN bio DROP NOT NULL;

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -266,118 +266,6 @@
       "nullable": []
     }
   },
-  "351af9c9c1c05556bdd8c373f406a66c9358c51dc4222f8abc5095fbf2458471": {
-    "query": "\n            SELECT u.id, u.name, u.email,\n                u.avatar_url, u.username, u.bio,\n                u.created\n            FROM users u\n            WHERE u.github_id = $1\n            ",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 1,
-          "name": "name",
-          "type_info": "Varchar"
-        },
-        {
-          "ordinal": 2,
-          "name": "email",
-          "type_info": "Varchar"
-        },
-        {
-          "ordinal": 3,
-          "name": "avatar_url",
-          "type_info": "Varchar"
-        },
-        {
-          "ordinal": 4,
-          "name": "username",
-          "type_info": "Varchar"
-        },
-        {
-          "ordinal": 5,
-          "name": "bio",
-          "type_info": "Varchar"
-        },
-        {
-          "ordinal": 6,
-          "name": "created",
-          "type_info": "Timestamptz"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Int8"
-        ]
-      },
-      "nullable": [
-        false,
-        false,
-        true,
-        false,
-        false,
-        false,
-        false
-      ]
-    }
-  },
-  "35272854c6aeb743218e73ccf6f34427ab72f25492dfa752f87a50e3da7204c5": {
-    "query": "\n            SELECT v.mod_id, v.name, v.version_number,\n                v.changelog_url, v.date_published, v.downloads,\n                release_channels.channel\n            FROM versions v\n            INNER JOIN release_channels ON v.release_channel = release_channels.id\n            WHERE v.id = $1\n            ",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "mod_id",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 1,
-          "name": "name",
-          "type_info": "Varchar"
-        },
-        {
-          "ordinal": 2,
-          "name": "version_number",
-          "type_info": "Varchar"
-        },
-        {
-          "ordinal": 3,
-          "name": "changelog_url",
-          "type_info": "Varchar"
-        },
-        {
-          "ordinal": 4,
-          "name": "date_published",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 5,
-          "name": "downloads",
-          "type_info": "Int4"
-        },
-        {
-          "ordinal": 6,
-          "name": "channel",
-          "type_info": "Varchar"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Int8"
-        ]
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        true,
-        false,
-        false,
-        false
-      ]
-    }
-  },
   "398ac436f5fe2f6a66544204b9ff01ae1ea1204edf03ffc16de657a861cfe0ba": {
     "query": "\n            DELETE FROM categories\n            WHERE category = $1\n            ",
     "describe": {
@@ -537,62 +425,6 @@
         ]
       },
       "nullable": [
-        false,
-        false,
-        false
-      ]
-    }
-  },
-  "5aaae159c75c9385f4d969338bce509852d4b3e3ae9d4c4e366055b5b499b19a": {
-    "query": "\n            SELECT v.mod_id, v.name, v.version_number,\n                v.changelog_url, v.date_published, v.downloads,\n                v.release_channel\n            FROM versions v\n            WHERE v.id = $1\n            ",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "mod_id",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 1,
-          "name": "name",
-          "type_info": "Varchar"
-        },
-        {
-          "ordinal": 2,
-          "name": "version_number",
-          "type_info": "Varchar"
-        },
-        {
-          "ordinal": 3,
-          "name": "changelog_url",
-          "type_info": "Varchar"
-        },
-        {
-          "ordinal": 4,
-          "name": "date_published",
-          "type_info": "Timestamptz"
-        },
-        {
-          "ordinal": 5,
-          "name": "downloads",
-          "type_info": "Int4"
-        },
-        {
-          "ordinal": 6,
-          "name": "release_channel",
-          "type_info": "Int4"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Int8"
-        ]
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        true,
         false,
         false,
         false
@@ -873,32 +705,6 @@
       "nullable": []
     }
   },
-  "a55925860b4a46af864a8c38f942d7cdd85c00638e761b9696de0bf47335173b": {
-    "query": "\n        SELECT mod_id, version_number\n        FROM versions\n        WHERE id = $1\n        ",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "mod_id",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 1,
-          "name": "version_number",
-          "type_info": "Varchar"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Int8"
-        ]
-      },
-      "nullable": [
-        false,
-        false
-      ]
-    }
-  },
   "a5d47fb171b0a1ba322125e7cedebf5af9c5831c319bbc4f8f087cb63322bee3": {
     "query": "\n            SELECT files.id, files.url, files.filename FROM files\n            WHERE files.version_id = $1\n            ",
     "describe": {
@@ -994,12 +800,12 @@
         ]
       },
       "nullable": [
-        false,
-        false,
         true,
         false,
+        true,
+        true,
         false,
-        false,
+        true,
         false,
         false
       ]
@@ -1523,31 +1329,12 @@
         false,
         false,
         true,
+        true,
         false,
-        false,
-        false,
+        true,
         false,
         false
       ]
-    }
-  },
-  "eaea3f606f926d7e1fc51a9798ce3c6448f0f02d55ce48bb38e84dc1bdced740": {
-    "query": "\n            INSERT INTO versions (\n                id, mod_id, name, version_number,\n                changelog_url, date_published,\n                downloads, release_channel\n            )\n            VALUES (\n                $1, $2, $3, $4,\n                $5, $6,\n                $7, $8\n            )\n            ",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Int8",
-          "Int8",
-          "Varchar",
-          "Varchar",
-          "Varchar",
-          "Timestamptz",
-          "Int4",
-          "Int4"
-        ]
-      },
-      "nullable": []
     }
   },
   "ebf2d1fbcd12816799b60be6e8dec606eadd96edc26a840a411b44a19dc0497c": {
@@ -1660,62 +1447,6 @@
         ]
       },
       "nullable": [
-        false
-      ]
-    }
-  },
-  "f772d6c3d287da99e00390517ea56cf3190658781da471bef58230e82b892b8c": {
-    "query": "\n            SELECT u.github_id, u.name, u.email,\n                u.avatar_url, u.username, u.bio,\n                u.created\n            FROM users u\n            WHERE u.id = $1\n            ",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "github_id",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 1,
-          "name": "name",
-          "type_info": "Varchar"
-        },
-        {
-          "ordinal": 2,
-          "name": "email",
-          "type_info": "Varchar"
-        },
-        {
-          "ordinal": 3,
-          "name": "avatar_url",
-          "type_info": "Varchar"
-        },
-        {
-          "ordinal": 4,
-          "name": "username",
-          "type_info": "Varchar"
-        },
-        {
-          "ordinal": 5,
-          "name": "bio",
-          "type_info": "Varchar"
-        },
-        {
-          "ordinal": 6,
-          "name": "created",
-          "type_info": "Timestamptz"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Int8"
-        ]
-      },
-      "nullable": [
-        false,
-        false,
-        true,
-        false,
-        false,
-        false,
         false
       ]
     }

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -58,7 +58,7 @@ where
     match res {
         Some(result) => Ok(User {
             id: UserId::from(result.id),
-            github_id: result.github_id as u64,
+            github_id: result.github_id.map(|i| i as u64),
             username: result.username,
             name: result.name,
             email: result.email,

--- a/src/database/models/user_item.rs
+++ b/src/database/models/user_item.rs
@@ -2,12 +2,12 @@ use super::ids::UserId;
 
 pub struct User {
     pub id: UserId,
-    pub github_id: i64,
+    pub github_id: Option<i64>,
     pub username: String,
     pub name: String,
     pub email: Option<String>,
-    pub avatar_url: String,
-    pub bio: String,
+    pub avatar_url: Option<String>,
+    pub bio: Option<String>,
     pub created: chrono::DateTime<chrono::Utc>,
     pub role: String,
 }
@@ -33,8 +33,8 @@ impl User {
             &self.username,
             &self.name,
             self.email.as_ref(),
-            &self.avatar_url,
-            &self.bio,
+            self.avatar_url.as_ref(),
+            self.bio.as_ref(),
             self.created,
         )
         .execute(&mut *transaction)
@@ -99,7 +99,7 @@ impl User {
         if let Some(row) = result {
             Ok(Some(User {
                 id: UserId(row.id),
-                github_id: github_id as i64,
+                github_id: Some(github_id as i64),
                 name: row.name,
                 email: row.email,
                 avatar_url: row.avatar_url,

--- a/src/database/postgres_database.rs
+++ b/src/database/postgres_database.rs
@@ -43,7 +43,7 @@ pub async fn run_migrations(uri: &str) -> Result<(), sqlx::Error> {
 
     for migration in migrator.iter() {
         if migration.version > version {
-            let elapsed = conn.apply(migration).await?;
+            let _elapsed = conn.apply(migration).await?;
         } else {
             conn.validate(migration).await?;
         }

--- a/src/models/mods.rs
+++ b/src/models/mods.rs
@@ -89,7 +89,7 @@ pub struct VersionFile {
     pub hashes: std::collections::HashMap<String, String>,
     /// A direct link to the file for downloading it.
     pub url: String,
-    /// A direct link to the file for downloading it.
+    /// The filename of the file.
     pub filename: String,
 }
 
@@ -101,14 +101,13 @@ pub enum VersionType {
     Alpha,
 }
 
-impl ToString for VersionType {
-    fn to_string(&self) -> String {
+impl std::fmt::Display for VersionType {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            VersionType::Release => "release",
-            VersionType::Beta => "beta",
-            VersionType::Alpha => "alpha",
+            VersionType::Release => write!(fmt, "release"),
+            VersionType::Beta => write!(fmt, "beta"),
+            VersionType::Alpha => write!(fmt, "alpha"),
         }
-        .to_string()
     }
 }
 
@@ -122,6 +121,8 @@ pub struct GameVersion(pub String);
 #[serde(transparent)]
 pub struct ModLoader(pub String);
 
+// These fields must always succeed parsing; deserialize errors aren't
+// processed correctly (don't return JSON errors)
 #[derive(Serialize, Deserialize)]
 pub struct SearchRequest {
     pub query: Option<String>,
@@ -133,5 +134,5 @@ pub struct SearchRequest {
     pub version: Option<String>,
     pub offset: Option<String>,
     pub index: Option<String>,
-    pub limit: Option<usize>,
+    pub limit: Option<String>,
 }

--- a/src/models/teams.rs
+++ b/src/models/teams.rs
@@ -2,7 +2,6 @@ use super::ids::Base62Id;
 use crate::models::users::UserId;
 use serde::{Deserialize, Serialize};
 
-//TODO Implement Item for teams
 /// The ID of a team
 #[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(from = "Base62Id")]
@@ -26,6 +25,6 @@ pub struct TeamMember {
     pub user_id: UserId,
     /// The name of the user
     pub name: String,
-    ///The role of the use in the team
+    /// The role of the user in the team
     pub role: String,
 }

--- a/src/models/users.rs
+++ b/src/models/users.rs
@@ -9,29 +9,30 @@ pub struct UserId(pub u64);
 #[derive(Serialize, Deserialize)]
 pub struct User {
     pub id: UserId,
-    pub github_id: u64,
+    pub github_id: Option<u64>,
     pub username: String,
     pub name: String,
     pub email: Option<String>,
-    pub avatar_url: String,
-    pub bio: String,
+    pub avatar_url: Option<String>,
+    pub bio: Option<String>,
     pub created: chrono::DateTime<chrono::Utc>,
     pub role: Role,
 }
 
 #[derive(Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Role {
     Developer,
     Moderator,
     Admin,
 }
 
-impl ToString for Role {
-    fn to_string(&self) -> String {
+impl std::fmt::Display for Role {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            Role::Developer => String::from("developer"),
-            Role::Moderator => String::from("moderator"),
-            Role::Admin => String::from("admin"),
+            Role::Developer => write!(fmt, "developer"),
+            Role::Moderator => write!(fmt, "moderator"),
+            Role::Admin => write!(fmt, "admin"),
         }
     }
 }

--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -182,12 +182,12 @@ pub async fn auth_callback(
 
             User {
                 id: user_id,
-                github_id: user.id as i64,
+                github_id: Some(user.id as i64),
                 username: user.login,
                 name: user.name,
                 email: user.email,
-                avatar_url: user.avatar_url,
-                bio: user.bio,
+                avatar_url: Some(user.avatar_url),
+                bio: Some(user.bio),
                 created: Utc::now(),
                 role: Role::Developer.to_string(),
             }

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -35,9 +35,7 @@ pub fn versions_config(cfg: &mut web::ServiceConfig) {
             web::scope("version")
                 .service(versions::version_get)
                 .service(versions::version_delete)
-                .service(
-                    web::scope("{version_id}").service(version_creation::upload_file_to_version),
-                ),
+                .service(version_creation::upload_file_to_version),
         );
 }
 

--- a/src/routes/users.rs
+++ b/src/routes/users.rs
@@ -1,10 +1,10 @@
 use crate::auth::{check_is_moderator_from_headers, get_user_from_headers};
 use crate::models::users::{Role, UserId};
 use crate::routes::ApiError;
-use actix_web::{delete, get, post, web, HttpRequest, HttpResponse};
+use actix_web::{delete, get, web, HttpRequest, HttpResponse};
 use sqlx::PgPool;
 
-#[post("mod")]
+#[get("user")]
 pub async fn user_auth_get(
     req: HttpRequest,
     pool: web::Data<PgPool>,
@@ -35,7 +35,7 @@ pub async fn user_get(
     if let Some(data) = user_data {
         let response = crate::models::users::User {
             id: data.id.into(),
-            github_id: data.github_id as u64,
+            github_id: data.github_id.map(|i| i as u64),
             username: data.username,
             name: data.name,
             email: None,

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -141,7 +141,7 @@ pub async fn search_for_mod(info: &SearchRequest) -> Result<SearchResults, Searc
 
     let offset = info.offset.as_deref().unwrap_or("0").parse()?;
     let index = info.index.as_deref().unwrap_or("relevance");
-    let limit = info.limit.unwrap_or(10);
+    let limit = info.limit.as_deref().unwrap_or("10").parse()?;
     let search_query: &str = info
         .query
         .as_deref()


### PR DESCRIPTION
Notable changes:
* Merged mod file upload in version creation, mod creation and version file add to one function;  This makes sure that they are consistent
* Made some fields on `User` optional: `github_id`, `avatar_url`, `bio`.
    * We may not want to publicly show the `github_id` to everyone with access to the API
    * If we allow non-github users, some of those fields would be invalid; some oauth providers may not have avatars or bios
* Made CORS origins configurable
* Made `--reconfigure-indices` and `--reset-indices` exit after completion instead of starting the server