### PR TITLE
Refactor mod creation route & Add more checks

### DIFF
--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -59,6 +59,46 @@
       "nullable": []
     }
   },
+  "0a3f99eae57c0c3d10aa0014db7fb8a33952da3e7d00949a25ade843859272cb": {
+    "query": "\n            SELECT id\n            FROM release_channels\n            WHERE channel = $1\n            ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Text"
+        ]
+      },
+      "nullable": [
+        false
+      ]
+    }
+  },
+  "0ca11a32b2860e4f5c3d20892a5be3cb419e084f42ba0f98e09b9995027fcc4e": {
+    "query": "\n            SELECT id FROM statuses\n            WHERE status = $1\n            ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Text"
+        ]
+      },
+      "nullable": [
+        false
+      ]
+    }
+  },
   "0da158263c6588a83421154342db2ede16b9abf9931827790b9fcaf71080c324": {
     "query": "\n                SELECT u.id, u.username FROM users u\n                INNER JOIN team_members tm ON tm.user_id = u.id\n                WHERE tm.team_id = $2 AND tm.role = $1\n                ",
     "describe": {
@@ -82,6 +122,26 @@
       },
       "nullable": [
         false,
+        false
+      ]
+    }
+  },
+  "0ef06dd5094da2458c558b115ed272da338ade372e717d8580cdf52c0000f80c": {
+    "query": "\n                SELECT user_id FROM team_members\n                WHERE team_id = $1\n                ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "user_id",
+          "type_info": "Int8"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8"
+        ]
+      },
+      "nullable": [
         false
       ]
     }
@@ -519,6 +579,46 @@
       "nullable": []
     }
   },
+  "40597b84607e77809c13ffa9c6b0b1674bd6378a4737a8f6118e91ae2ede7e4a": {
+    "query": "\n                SELECT id\n                FROM release_channels\n                WHERE channel = $1\n                ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Text"
+        ]
+      },
+      "nullable": [
+        false
+      ]
+    }
+  },
+  "42e072309779598d0c213280dd8052d1b4889cb24ef5204ca13b74f693b94328": {
+    "query": "\n                SELECT user_id FROM team_members tm\n                INNER JOIN mods ON mods.team_id = tm.team_id\n                WHERE mods.id = $1\n                ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "user_id",
+          "type_info": "Int8"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8"
+        ]
+      },
+      "nullable": [
+        false
+      ]
+    }
+  },
   "4411f2aefd43881450da34db81e826110ac86c3a6cef9fd6a3e9e341508d1f09": {
     "query": "\n                SELECT id FROM versions\n                WHERE mod_id = $1\n                ",
     "describe": {
@@ -552,6 +652,26 @@
         ]
       },
       "nullable": []
+    }
+  },
+  "4c98e4441f8168d00bc7ff47951f15b44ff884cff6fc484645c74bfe3e7e7020": {
+    "query": "\n            SELECT id\n            FROM statuses\n            WHERE status = $1\n            ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Text"
+        ]
+      },
+      "nullable": [
+        false
+      ]
     }
   },
   "4c99c0840159d18e88cd6094a41117258f2337346c145d926b5b610c76b5125f": {
@@ -1403,6 +1523,26 @@
       },
       "nullable": [
         null
+      ]
+    }
+  },
+  "cf031f19c7882833a8a30348ee90175a5d8b1fb7d9645c5deb2dc68c6eb33683": {
+    "query": "\n            SELECT id FROM release_channels\n            WHERE channel = $1\n            ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int4"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Text"
+        ]
+      },
+      "nullable": [
+        false
       ]
     }
   },

--- a/src/database/models/ids.rs
+++ b/src/database/models/ids.rs
@@ -88,7 +88,7 @@ generate_ids!(
     UserId
 );
 
-#[derive(Copy, Clone, Debug, Type)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Type)]
 #[sqlx(transparent)]
 pub struct UserId(pub i64);
 

--- a/src/database/models/mod.rs
+++ b/src/database/models/mod.rs
@@ -31,3 +31,47 @@ pub enum DatabaseError {
     )]
     InvalidIdentifier(String),
 }
+
+impl ids::ChannelId {
+    pub async fn get_id<'a, E>(
+        channel: &str,
+        exec: E,
+    ) -> Result<Option<ids::ChannelId>, DatabaseError>
+    where
+        E: sqlx::Executor<'a, Database = sqlx::Postgres>,
+    {
+        let result = sqlx::query!(
+            "
+            SELECT id FROM release_channels
+            WHERE channel = $1
+            ",
+            channel
+        )
+        .fetch_optional(exec)
+        .await?;
+
+        Ok(result.map(|r| ids::ChannelId(r.id)))
+    }
+}
+
+impl ids::StatusId {
+    pub async fn get_id<'a, E>(
+        status: &crate::models::mods::ModStatus,
+        exec: E,
+    ) -> Result<Option<Self>, DatabaseError>
+    where
+        E: sqlx::Executor<'a, Database = sqlx::Postgres>,
+    {
+        let result = sqlx::query!(
+            "
+            SELECT id FROM statuses
+            WHERE status = $1
+            ",
+            status.as_str()
+        )
+        .fetch_optional(exec)
+        .await?;
+
+        Ok(result.map(|r| ids::StatusId(r.id)))
+    }
+}

--- a/src/models/mods.rs
+++ b/src/models/mods.rs
@@ -72,12 +72,12 @@ pub enum ModStatus {
 impl std::fmt::Display for ModStatus {
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            ModStatus::Approved => write!(fmt, "release"),
-            ModStatus::Rejected => write!(fmt, "beta"),
-            ModStatus::Draft => write!(fmt, "alpha"),
+            ModStatus::Approved => write!(fmt, "approved"),
+            ModStatus::Rejected => write!(fmt, "rejected"),
+            ModStatus::Draft => write!(fmt, "draft"),
             ModStatus::Unlisted => write!(fmt, "unlisted"),
-            ModStatus::Processing => write!(fmt, "Processing"),
-            ModStatus::Unknown => write!(fmt, "Unknown"),
+            ModStatus::Processing => write!(fmt, "processing"),
+            ModStatus::Unknown => write!(fmt, "unknown"),
         }
     }
 }
@@ -86,11 +86,21 @@ impl ModStatus {
     pub fn from_str(string: &str) -> ModStatus {
         match string {
             "processing" => ModStatus::Processing,
-            "rejected" => ModStatus::Processing,
-            "approved" => ModStatus::Processing,
-            "draft" => ModStatus::Processing,
-            "unlisted" => ModStatus::Processing,
+            "rejected" => ModStatus::Rejected,
+            "approved" => ModStatus::Approved,
+            "draft" => ModStatus::Draft,
+            "unlisted" => ModStatus::Unlisted,
             _ => ModStatus::Unknown,
+        }
+    }
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ModStatus::Approved => "approved",
+            ModStatus::Rejected => "rejected",
+            ModStatus::Draft => "draft",
+            ModStatus::Unlisted => "unlisted",
+            ModStatus::Processing => "processing",
+            ModStatus::Unknown => "unknown",
         }
     }
 }
@@ -154,6 +164,17 @@ impl std::fmt::Display for VersionType {
             VersionType::Release => write!(fmt, "release"),
             VersionType::Beta => write!(fmt, "beta"),
             VersionType::Alpha => write!(fmt, "alpha"),
+        }
+    }
+}
+
+impl VersionType {
+    // These are constant, so this can remove unneccessary allocations (`to_string`)
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            VersionType::Release => "release",
+            VersionType::Beta => "beta",
+            VersionType::Alpha => "alpha",
         }
     }
 }


### PR DESCRIPTION
This removes the `team_members` field of `InitialModData`, as team members are no longer specified at mod creation.
This adds length limits to most fields in mod creation, and adds file size limits: 64KiB for mod and version descriptions, 16KiB for mod icons, and 25MiB for mod files.
This makes the description/changelog for versions optional at creation to match other usages.