### PR TITLE
Fix indexing, upgrade MeiliSearch sdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1726,15 +1726,14 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "meilisearch-sdk"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9e61da1ebd3d15e0aaa978d3f1f080e3793494ddea0bc6703da4b330ea1ffc"
+checksum = "cb2081610089deb10290747b8782049f9cb64a70a4d305a28970db8b780d1448"
 dependencies = [
  "log",
  "reqwest",
  "serde",
  "serde_json",
- "urlencoding",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -3008,12 +3007,6 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9232eb53352b4442e40d7900465dfc534e8cb2dc8f18656fcb2ac16112b5593"
 
 [[package]]
 name = "v_escape"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ actix-files = "0.4.0"
 actix-multipart = "0.3.0"
 actix-cors = "0.4.1"
 
-meilisearch-sdk = "0.3.0"
+meilisearch-sdk = "0.4.0"
 reqwest = { version = "0.10.8", features = ["json"] }
 
 serde_json = "1.0"

--- a/src/search/indexing/curseforge_import.rs
+++ b/src/search/indexing/curseforge_import.rs
@@ -119,21 +119,23 @@ lazy_static::lazy_static! {
 pub async fn index_curseforge(
     start_index: u32,
     end_index: u32,
-    cache_path: &std::path::Path,
+    cache_path: Option<&std::path::Path>,
 ) -> Result<Vec<UploadSearchMod>, IndexingError> {
     info!("Indexing curseforge mods!");
     let start = std::time::Instant::now();
 
     let mut docs_to_add: Vec<UploadSearchMod> = vec![];
 
-    let cache = std::fs::File::open(cache_path)
+    let cache = cache_path
+        .map(std::fs::File::open)
+        .and_then(Result::ok)
         .map(std::io::BufReader::new)
         .map(serde_json::from_reader::<_, Vec<u32>>);
 
     let requested_ids;
 
     // This caching system can't handle segmented indexing
-    if let Ok(Ok(mut cache)) = cache {
+    if let Some(Ok(mut cache)) = cache {
         let end = cache.last().copied().unwrap_or(start_index);
         cache.extend(end..end_index);
         requested_ids = serde_json::to_string(&cache)?;
@@ -167,11 +169,13 @@ pub async fn index_curseforge(
     // Only write to the cache if this doesn't skip mods at the start
     // The caching system iterates through all ids normally past the last
     // id in the cache, so the end_index shouldn't matter.
-    if start_index <= 1 {
-        let mut ids = curseforge_mods.iter().map(|m| m.id).collect::<Vec<_>>();
-        ids.sort_unstable();
-        if let Err(e) = std::fs::write(cache_path, serde_json::to_string(&ids)?) {
-            log::warn!("Error writing to index id cache: {}", e);
+    if let Some(path) = cache_path {
+        if start_index <= 1 {
+            let mut ids = curseforge_mods.iter().map(|m| m.id).collect::<Vec<_>>();
+            ids.sort_unstable();
+            if let Err(e) = std::fs::write(path, serde_json::to_string(&ids)?) {
+                log::warn!("Error writing to index id cache: {}", e);
+            }
         }
     }
 

--- a/src/search/indexing/curseforge_import.rs
+++ b/src/search/indexing/curseforge_import.rs
@@ -313,7 +313,6 @@ pub async fn index_curseforge(
             modified_timestamp: curseforge_mod.date_modified.timestamp(),
             latest_version,
             host: Cow::Borrowed("curseforge"),
-            empty: Cow::Borrowed("{}{}{}"),
         })
     }
 

--- a/src/search/indexing/curseforge_import.rs
+++ b/src/search/indexing/curseforge_import.rs
@@ -196,8 +196,8 @@ pub async fn index_curseforge(
         for file in curseforge_mod.latest_files {
             for version in file.game_version {
                 match &*version {
-                    "Fabric" => loaders.forge = true,
-                    "Forge" => loaders.fabric = true,
+                    "Fabric" => loaders.fabric = true,
+                    "Forge" => loaders.forge = true,
                     "Rift" => loaders.rift = true,
                     _ => (),
                 }

--- a/src/search/indexing/local_import.rs
+++ b/src/search/indexing/local_import.rs
@@ -112,7 +112,6 @@ pub async fn index_local(pool: PgPool) -> Result<Vec<UploadSearchMod>, IndexingE
                 modified_timestamp: mod_data.updated.timestamp(),
                 latest_version,
                 host: Cow::Borrowed("modrinth"),
-                empty: Cow::Borrowed("{}{}{}"),
             });
         }
     }
@@ -225,6 +224,5 @@ pub async fn query_one(
         modified_timestamp: mod_data.updated.timestamp(),
         latest_version,
         host: Cow::Borrowed("modrinth"),
-        empty: Cow::Borrowed("{}{}{}"),
     })
 }

--- a/src/search/indexing/mod.rs
+++ b/src/search/indexing/mod.rs
@@ -63,7 +63,7 @@ pub async fn index_mods(
 ) -> Result<(), IndexingError> {
     let mut docs_to_add: Vec<UploadSearchMod> = vec![];
 
-    let cache_path = std::path::PathBuf::from(std::env::var_os("INDEX_CACHE_PATH").unwrap());
+    let cache_path = std::env::var_os("INDEX_CACHE_PATH").map(std::path::PathBuf::from);
 
     if settings.index_local {
         docs_to_add.append(&mut index_local(pool.clone()).await?);
@@ -74,7 +74,7 @@ pub async fn index_mods(
             .map(|i| i.parse().unwrap())
             .unwrap_or(450_000);
 
-        docs_to_add.append(&mut index_curseforge(1, end_index, &cache_path).await?);
+        docs_to_add.append(&mut index_curseforge(1, end_index, cache_path.as_deref()).await?);
     }
 
     // Write Indices

--- a/src/search/indexing/mod.rs
+++ b/src/search/indexing/mod.rs
@@ -270,7 +270,6 @@ fn default_settings() -> Settings {
         "categories".to_string(),
         "versions".to_string(),
         "author".to_string(),
-        "empty".to_string(),
     ];
 
     Settings::new()


### PR DESCRIPTION
I'm not sure if upgrading the sdk was required for supporting the newer MeiliSearch version, but it would be a good idea anyway.  We should probably pin the MeiliSearch version so that we only have to upgrade it when we intend to rather than when they push a new (and potentially unstable) version.

This adds handling for the case where the `INDEX_CACHE_PATH` variable is missing, which should fix the issue with search.  It also makes the server exit on startup if environment variables are missing to prevent this sort of thing from potentially happening again for required variables.  The `--allow-missing-vars` commandline argument disables this if necessary, but it should not be used for a running server.

This also disables the query loggers as requested on discord.