### PR TITLE
Minor fixes to orderings and permission serialization

### DIFF
--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -1137,6 +1137,26 @@
       "nullable": []
     }
   },
+  "78c8b561e37e3aed48d3a4108ce7fd81866c6835ea91517ffc90c30e1284246e": {
+    "query": "\n            SELECT id FROM versions\n            WHERE mod_id = $1\n            ORDER BY date_published ASC\n            ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int8"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8"
+        ]
+      },
+      "nullable": [
+        false
+      ]
+    }
+  },
   "7bbbeecf3246a8e07ad073a07f7d057e0990a810d69ae18cec41de60b704b174": {
     "query": "\n            SELECT id, user_id, member_name, role, permissions, accepted\n            FROM team_members\n            WHERE (team_id = $1 AND user_id = $2 AND accepted = TRUE)\n            ",
     "describe": {
@@ -1428,6 +1448,24 @@
         ]
       },
       "nullable": []
+    }
+  },
+  "a82f1a23eaa2d6a0d1b331ce68c3fa307a20bbcde9b4846cea06e5502cb77a78": {
+    "query": "\n            SELECT loader FROM loaders\n            ORDER BY loader ASC\n            ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "loader",
+          "type_info": "Varchar"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false
+      ]
     }
   },
   "a94eb4862ba30ca21f15198d9b7b9fd80ce01d45457e0b4d68270b5e3f9be8c6": {
@@ -2206,6 +2244,24 @@
         "Left": [
           "Int8"
         ]
+      },
+      "nullable": [
+        false
+      ]
+    }
+  },
+  "ed2e4c5bf2df01ef670f5b0b4c3bd4b9aae9b7019938542a1b39ebd23d616617": {
+    "query": "\n            SELECT category FROM categories\n            ORDER BY category ASC\n            ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "category",
+          "type_info": "Varchar"
+        }
+      ],
+      "parameters": {
+        "Left": []
       },
       "nullable": [
         false

--- a/src/database/models/team_item.rs
+++ b/src/database/models/team_item.rs
@@ -107,7 +107,7 @@ impl TeamMember {
             if let Some(m) = e.right() {
                 let permissions = Permissions::from_bits(m.permissions as u64);
                 if let Some(perms) = permissions {
-                    Ok(Some(TeamMember {
+                    Ok(Some(Ok(TeamMember {
                         id: TeamMemberId(m.id),
                         team_id: id,
                         user_id: UserId(m.user_id),
@@ -115,16 +115,20 @@ impl TeamMember {
                         role: m.role,
                         permissions: perms,
                         accepted: m.accepted,
-                    }))
+                    })))
                 } else {
-                    Ok(None)
+                    Ok(Some(Err(super::DatabaseError::BitflagError)))
                 }
             } else {
                 Ok(None)
             }
         })
-        .try_collect::<Vec<TeamMember>>()
+        .try_collect::<Vec<Result<TeamMember, super::DatabaseError>>>()
         .await?;
+
+        let team_members = team_members
+            .into_iter()
+            .collect::<Result<Vec<TeamMember>, super::DatabaseError>>()?;
 
         Ok(team_members)
     }
@@ -152,7 +156,7 @@ impl TeamMember {
             if let Some(m) = e.right() {
                 let permissions = Permissions::from_bits(m.permissions as u64);
                 if let Some(perms) = permissions {
-                    Ok(Some(TeamMember {
+                    Ok(Some(Ok(TeamMember {
                         id: TeamMemberId(m.id),
                         team_id: TeamId(m.team_id),
                         user_id: id,
@@ -160,16 +164,20 @@ impl TeamMember {
                         role: m.role,
                         permissions: perms,
                         accepted: m.accepted,
-                    }))
+                    })))
                 } else {
-                    Ok(None)
+                    Ok(Some(Err(super::DatabaseError::BitflagError)))
                 }
             } else {
                 Ok(None)
             }
         })
-        .try_collect::<Vec<TeamMember>>()
+        .try_collect::<Vec<Result<TeamMember, super::DatabaseError>>>()
         .await?;
+
+        let team_members = team_members
+            .into_iter()
+            .collect::<Result<Vec<TeamMember>, super::DatabaseError>>()?;
 
         Ok(team_members)
     }

--- a/src/database/models/version_item.rs
+++ b/src/database/models/version_item.rs
@@ -331,6 +331,7 @@ impl Version {
             "
             SELECT id FROM versions
             WHERE mod_id = $1
+            ORDER BY date_published ASC
             ",
             mod_id as ModId,
         )

--- a/src/models/teams.rs
+++ b/src/models/teams.rs
@@ -22,6 +22,7 @@ pub struct Team {
 
 bitflags::bitflags! {
     #[derive(Serialize, Deserialize)]
+    #[serde(transparent)]
     pub struct Permissions: u64 {
         const UPLOAD_VERSION = 1 << 0;
         const DELETE_VERSION = 1 << 1;
@@ -51,5 +52,5 @@ pub struct TeamMember {
     /// The role of the user in the team
     pub role: String,
     /// A bitset containing the user's permissions in this team
-    pub permissions: Permissions,
+    pub permissions: Option<Permissions>,
 }

--- a/src/routes/teams.rs
+++ b/src/routes/teams.rs
@@ -30,7 +30,7 @@ pub async fn team_members_get(
                     user_id: data.user_id.into(),
                     name: data.name,
                     role: data.role,
-                    permissions: data.permissions,
+                    permissions: Some(data.permissions),
                 })
                 .collect();
 
@@ -44,7 +44,7 @@ pub async fn team_members_get(
             user_id: data.user_id.into(),
             name: data.name,
             role: data.role,
-            permissions: Permissions::default(),
+            permissions: None,
         })
         .collect();
 

--- a/src/routes/users.rs
+++ b/src/routes/users.rs
@@ -1,6 +1,5 @@
 use crate::auth::{check_is_moderator_from_headers, get_user_from_headers};
 use crate::database::models::{TeamMember, User};
-use crate::models::teams::Permissions;
 use crate::models::users::{Role, UserId};
 use crate::routes::ApiError;
 use actix_web::{delete, get, web, HttpRequest, HttpResponse};
@@ -152,9 +151,9 @@ pub async fn teams(
             name: data.name,
             role: data.role,
             permissions: if same_user {
-                data.permissions
+                Some(data.permissions)
             } else {
-                Permissions::default()
+                None
             },
         })
         .collect();

--- a/src/search/indexing/local_import.rs
+++ b/src/search/indexing/local_import.rs
@@ -22,7 +22,7 @@ pub async fn index_local(pool: PgPool) -> Result<Vec<UploadSearchMod>, IndexingE
         if let Ok(mod_data) = result {
             let versions = sqlx::query!(
                 "
-                SELECT gv.version FROM versions
+                SELECT DISTINCT gv.version, gv.created FROM versions
                     INNER JOIN game_versions_versions gvv ON gvv.joining_version_id=versions.id
                     INNER JOIN game_versions gv ON gvv.game_version_id=gv.id
                 WHERE versions.mod_id = $1
@@ -90,7 +90,7 @@ pub async fn index_local(pool: PgPool) -> Result<Vec<UploadSearchMod>, IndexingE
             // minecraft that this mod has a version that supports; it doesn't
             // take betas or other info into account.
             let latest_version = versions
-                .get(0)
+                .last()
                 .cloned()
                 .map(Cow::Owned)
                 .unwrap_or_else(|| Cow::Borrowed(""));
@@ -134,7 +134,7 @@ pub async fn query_one(
 
     let versions = sqlx::query!(
         "
-        SELECT gv.version FROM versions
+        SELECT DISTINCT gv.version, gv.created FROM versions
             INNER JOIN game_versions_versions gvv ON gvv.joining_version_id=versions.id
             INNER JOIN game_versions gv ON gvv.game_version_id=gv.id
         WHERE versions.mod_id = $1
@@ -202,7 +202,7 @@ pub async fn query_one(
     // minecraft that this mod has a version that supports; it doesn't
     // take betas or other info into account.
     let latest_version = versions
-        .get(0)
+        .last()
         .cloned()
         .map(Cow::Owned)
         .unwrap_or_else(|| Cow::Borrowed(""));


### PR DESCRIPTION
* Fixes the local indexer to use the most recently released minecraft version rather than the oldest version
* Fixes the case where a user with invalid permissions would be skipped when listing rather than throwing an error
* Specifies some previously random sort orderings
* Changes `Permissions` to be optional in the `TeamMember` struct and use `#[serde(transparent)]`, making it represented as a normal integer in JSON