### PR TITLE
Hotfix: route new moderation routes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -255,7 +255,8 @@ async fn main() -> std::io::Result<()> {
                     .configure(routes::mods_config)
                     .configure(routes::versions_config)
                     .configure(routes::teams_config)
-                    .configure(routes::users_config),
+                    .configure(routes::users_config)
+                    .configure(routes::moderation_config),
             )
             .default_service(web::get().to(routes::not_found))
     })

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -74,6 +74,14 @@ pub fn teams_config(cfg: &mut web::ServiceConfig) {
     );
 }
 
+pub fn moderation_config(cfg: &mut web::ServiceConfig) {
+    cfg.service(
+        web::scope("moderation")
+            .service(moderation::mods)
+            .service(moderation::versions),
+    );
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum ApiError {
     #[error("Error while uploading file")]


### PR DESCRIPTION
The last PR didn't add routing for the new moderation routes, making approving mods impossible without direct database access.