### PR TITLE
Hotfix: fix version delete permissions and CORS allowed methods

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -280,7 +280,7 @@ async fn main() -> std::io::Result<()> {
     // Init App
     HttpServer::new(move || {
         let mut cors = Cors::new()
-            .allowed_methods(vec!["GET", "POST"])
+            .allowed_methods(vec!["GET", "POST", "DELETE", "PATCH", "PUT"])
             .allowed_headers(vec![http::header::AUTHORIZATION, http::header::ACCEPT])
             .allowed_header(http::header::CONTENT_TYPE)
             .max_age(3600);


### PR DESCRIPTION
This fixes a major bug in the version deletion API route, and adds `DELETE`, `PATCH` and `PUT` to the CORS allowed methods.