### PR TITLE
Detect if redirect url contains a query string

### DIFF
--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -199,7 +199,11 @@ pub async fn auth_callback(
 
         transaction.commit().await?;
 
-        let redirect_url = format!("{}?code={}", result.url, token.access_token);
+        let redirect_url = if result.url.contains("?") {
+          format!("{}&code={}", result.url, token.access_token)
+        } else {
+          format!("{}?code={}", result.url, token.access_token)
+        };
 
         Ok(HttpResponse::TemporaryRedirect()
             .header("Location", &*redirect_url)


### PR DESCRIPTION
Currently, when auth redirects a user back to the frontend, it doesn't account for situations where the redirect URL already includes a query string. This results in issues such as the mod search page interpreting the code as a search term:
![image](https://user-images.githubusercontent.com/44736536/127104152-66f1d493-e658-4b2d-959f-5889d26ce454.png)
