### PR TITLE
Maven repo should return primary file by default

### DIFF
--- a/src/routes/maven.rs
+++ b/src/routes/maven.rs
@@ -234,6 +234,10 @@ pub async fn version_file(
             return Ok(HttpResponse::TemporaryRedirect()
                 .header("Location", &*selected_file.url)
                 .body(""));
+        } else if let Some(selected_file) = version.files.iter().last() {
+            return Ok(HttpResponse::TemporaryRedirect()
+                .header("Location", &*selected_file.url)
+                .body(""));
         }
     }
 

--- a/src/routes/maven.rs
+++ b/src/routes/maven.rs
@@ -230,7 +230,7 @@ pub async fn version_file(
             .header("Location", &*selected_file.url)
             .body(""));
     } else if file == format!("{}-{}.jar", &string, &version.version_number) {
-        if let Some(selected_file) = version.files.iter().last() {
+        if let Some(selected_file) = version.files.iter().find(|x| x.primary) {
             return Ok(HttpResponse::TemporaryRedirect()
                 .header("Location", &*selected_file.url)
                 .body(""));


### PR DESCRIPTION
The title is pretty much self-descriptive - maven repository should return primary file for `{id}-{version}.jar` queries. At the moment it returns last file provided by the database, which can be pretty random:

https://github.com/modrinth/labrinth/blob/91065a616893dbc1c19447057fce3c0b4b59fc21/src/database/models/version_item.rs#L634-L636

As you can see, no `ORDER BY` is specified, therefore we **cannot** rely on the order.