### PR TITLE
Don't consider a user's name taken by self

### DIFF
--- a/src/routes/users.rs
+++ b/src/routes/users.rs
@@ -191,7 +191,7 @@ pub async fn user_edit(
                 if existing_user_id_option
                     .map(UserId::from)
                     .map(|id| id == user.id)
-                    .unwrap_or(false)
+                    .unwrap_or(true)
                 {
                     sqlx::query!(
                         "

--- a/src/routes/users.rs
+++ b/src/routes/users.rs
@@ -182,13 +182,13 @@ pub async fn user_edit(
             let mut transaction = pool.begin().await?;
 
             if let Some(username) = &new_user.username {
-                let user_option =
+                let existing_user_id_option =
                     crate::database::models::User::get_id_from_username_or_id(
                         username, &**pool,
                     )
                     .await?;
 
-                if user_option.is_none() {
+                if existing_user_id_option.is_none() || existing_user_id_option.unwrap() == user.id {
                     sqlx::query!(
                         "
                     UPDATE users

--- a/src/routes/users.rs
+++ b/src/routes/users.rs
@@ -188,7 +188,9 @@ pub async fn user_edit(
                     )
                     .await?;
 
-                if existing_user_id_option.is_none() || existing_user_id_option.unwrap() == user.id {
+                if existing_user_id_option.is_none()
+                    || UserId::from(existing_user_id_option.unwrap()) == user.id
+                {
                     sqlx::query!(
                         "
                     UPDATE users

--- a/src/routes/users.rs
+++ b/src/routes/users.rs
@@ -188,8 +188,10 @@ pub async fn user_edit(
                     )
                     .await?;
 
-                if existing_user_id_option.is_none()
-                    || UserId::from(existing_user_id_option.unwrap()) == user.id
+                if existing_user_id_option
+                    .map(UserId::from)
+                    .map(|id| id == user.id)
+                    .unwrap_or(false)
                 {
                     sqlx::query!(
                         "


### PR DESCRIPTION
Relevant thread: https://discord.com/channels/734077874708938864/983131461647470592

Essentially, users cannot change the capitalization of their name, due to the current implementation of the "username taken" check.

---

Worth noting that I've not actually tested this locally due to local devenv issues I'm currently in the process of resolving.