### PR TITLE
Add auto-reporting inappropriate text content

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,6 +585,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "censor"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5563d2728feef9a6186acdd148bccbe850dad63c5ba55a3b3355abc9137cb3eb"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1456,6 +1465,7 @@ dependencies = [
  "bitflags",
  "bytes",
  "cached",
+ "censor",
  "dashmap",
  "dotenv",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,3 +64,5 @@ bytes = "1.1.0"
 dashmap = "5.2.0"
 
 cached = "0.34.0"
+
+censor = "0.2.0"

--- a/src/database/models/ids.rs
+++ b/src/database/models/ids.rs
@@ -13,6 +13,7 @@ macro_rules! generate_ids {
             let length = $id_length;
             let mut id = random_base62_rng(&mut rng, length);
             let mut retry_count = 0;
+            let censor = Censor::Standard + Censor::Sex;
 
             // Check if ID is unique
             loop {
@@ -20,7 +21,7 @@ macro_rules! generate_ids {
                     .fetch_one(&mut *con)
                     .await?;
 
-                if results.exists.unwrap_or(true) {
+                if results.exists.unwrap_or(true) || !censor.check(id) {
                     id = random_base62_rng(&mut rng, length);
                 } else {
                     break;

--- a/src/database/models/ids.rs
+++ b/src/database/models/ids.rs
@@ -23,7 +23,7 @@ macro_rules! generate_ids {
                     .fetch_one(&mut *con)
                     .await?;
 
-                if results.exists.unwrap_or(true) || !censor.check(&*to_base62(id)) {
+                if results.exists.unwrap_or(true) || censor.check(&*to_base62(id)) {
                     id = random_base62_rng(&mut rng, length);
                 } else {
                     break;

--- a/src/database/models/ids.rs
+++ b/src/database/models/ids.rs
@@ -1,5 +1,7 @@
 use super::DatabaseError;
+use crate::models::ids::base62_impl::to_base62;
 use crate::models::ids::random_base62_rng;
+use censor::Censor;
 use sqlx::sqlx_macros::Type;
 
 const ID_RETRY_COUNT: usize = 20;
@@ -21,7 +23,7 @@ macro_rules! generate_ids {
                     .fetch_one(&mut *con)
                     .await?;
 
-                if results.exists.unwrap_or(true) || !censor.check(id) {
+                if results.exists.unwrap_or(true) || !censor.check(&*to_base62(id)) {
                     id = random_base62_rng(&mut rng, length);
                 } else {
                     break;

--- a/src/database/models/report_item.rs
+++ b/src/database/models/report_item.rs
@@ -8,7 +8,7 @@ pub struct Report {
     pub version_id: Option<VersionId>,
     pub user_id: Option<UserId>,
     pub body: String,
-    pub reporter: Option<UserId>,
+    pub reporter: UserId,
     pub created: OffsetDateTime,
 }
 
@@ -19,7 +19,7 @@ pub struct QueryReport {
     pub version_id: Option<VersionId>,
     pub user_id: Option<UserId>,
     pub body: String,
-    pub reporter: Option<UserId>,
+    pub reporter: UserId,
     pub created: OffsetDateTime,
 }
 
@@ -80,7 +80,7 @@ impl Report {
                 version_id: row.version_id.map(VersionId),
                 user_id: row.user_id.map(UserId),
                 body: row.body,
-                reporter: row.reporter.map(UserId),
+                reporter: UserId(row.reporter),
                 created: row.created,
             }))
         } else {
@@ -118,7 +118,7 @@ impl Report {
                 version_id: x.version_id.map(VersionId),
                 user_id: x.user_id.map(UserId),
                 body: x.body,
-                reporter: x.reporter.map(UserId),
+                reporter: UserId(x.reporter),
                 created: x.created,
             }))
         })

--- a/src/database/models/report_item.rs
+++ b/src/database/models/report_item.rs
@@ -8,7 +8,7 @@ pub struct Report {
     pub version_id: Option<VersionId>,
     pub user_id: Option<UserId>,
     pub body: String,
-    pub reporter: UserId,
+    pub reporter: Option<UserId>,
     pub created: OffsetDateTime,
 }
 
@@ -19,7 +19,7 @@ pub struct QueryReport {
     pub version_id: Option<VersionId>,
     pub user_id: Option<UserId>,
     pub body: String,
-    pub reporter: UserId,
+    pub reporter: Option<UserId>,
     pub created: OffsetDateTime,
 }
 
@@ -80,7 +80,7 @@ impl Report {
                 version_id: row.version_id.map(VersionId),
                 user_id: row.user_id.map(UserId),
                 body: row.body,
-                reporter: UserId(row.reporter),
+                reporter: row.reporter.map(UserId),
                 created: row.created,
             }))
         } else {
@@ -118,7 +118,7 @@ impl Report {
                 version_id: x.version_id.map(VersionId),
                 user_id: x.user_id.map(UserId),
                 body: x.body,
-                reporter: UserId(x.reporter),
+                reporter: x.reporter.map(UserId),
                 created: x.created,
             }))
         })

--- a/src/routes/projects.rs
+++ b/src/routes/projects.rs
@@ -11,6 +11,7 @@ use crate::util::auth::{get_user_from_headers, is_authorized};
 use crate::util::routes::read_from_payload;
 use crate::util::validate::validation_errors_to_string;
 use actix_web::{delete, get, patch, post, web, HttpRequest, HttpResponse};
+use censor::Censor;
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -387,6 +388,15 @@ pub async fn project_edit(
                 )
                 .execute(&mut *transaction)
                 .await?;
+
+                crate::util::report::censor_check(
+                    &*title,
+                    Some(project_item.inner.id),
+                    None,
+                    None,
+                    "Project edited with inappropriate title".to_string(),
+                    &mut transaction,
+                );
             }
 
             if let Some(description) = &new_project.description {
@@ -408,6 +418,15 @@ pub async fn project_edit(
                 )
                 .execute(&mut *transaction)
                 .await?;
+
+                crate::util::report::censor_check(
+                    &*description,
+                    Some(project_item.inner.id),
+                    None,
+                    None,
+                    "Project edited with inappropriate description".to_string(),
+                    &mut transaction,
+                );
             }
 
             if let Some(status) = &new_project.status {
@@ -692,6 +711,15 @@ pub async fn project_edit(
                 )
                 .execute(&mut *transaction)
                 .await?;
+
+                crate::util::report::censor_check(
+                    &*slug.as_deref(),
+                    Some(project_item.inner.id),
+                    None,
+                    None,
+                    "Project edited with inappropriate slug".to_string(),
+                    &mut transaction,
+                );
             }
 
             if let Some(new_side) = &new_project.client_side {
@@ -891,6 +919,15 @@ pub async fn project_edit(
                 )
                 .execute(&mut *transaction)
                 .await?;
+
+                crate::util::report::censor_check(
+                    &*body,
+                    Some(project_item.inner.id),
+                    None,
+                    None,
+                    "Project edited with inappropriate body".to_string(),
+                    &mut transaction,
+                );
             }
 
             transaction.commit().await?;

--- a/src/routes/users.rs
+++ b/src/routes/users.rs
@@ -204,6 +204,17 @@ pub async fn user_edit(
                     )
                     .execute(&mut *transaction)
                     .await?;
+
+                    crate::util::report::censor_check(
+                        &*username,
+                        None,
+                        None,
+                        Some(crate::database::models::ids::UserId::from(
+                            user_id,
+                        )),
+                        "User edited with inappropriate username".to_string(),
+                        &mut transaction,
+                    );
                 } else {
                     return Err(ApiError::InvalidInput(format!(
                         "Username {} is taken!",
@@ -224,6 +235,17 @@ pub async fn user_edit(
                 )
                 .execute(&mut *transaction)
                 .await?;
+
+                crate::util::report::censor_check(
+                    &*name.as_deref(),
+                    None,
+                    None,
+                    Some(crate::database::models::ids::UserId::from(
+                        user_id,
+                    )),
+                    "User edited with inappropriate name".to_string(),
+                    &mut transaction,
+                );
             }
 
             if let Some(bio) = &new_user.bio {
@@ -238,6 +260,17 @@ pub async fn user_edit(
                 )
                 .execute(&mut *transaction)
                 .await?;
+
+                crate::util::report::censor_check(
+                    &*bio.as_deref(),
+                    None,
+                    None,
+                    Some(crate::database::models::ids::UserId::from(
+                        user_id,
+                    )),
+                    "User edited with inappropriate bio".to_string(),
+                    &mut transaction,
+                );
             }
 
             if let Some(email) = &new_user.email {

--- a/src/routes/users.rs
+++ b/src/routes/users.rs
@@ -214,7 +214,8 @@ pub async fn user_edit(
                         )),
                         "User edited with inappropriate username".to_string(),
                         &mut transaction,
-                    );
+                    )
+                    .await?;
                 } else {
                     return Err(ApiError::InvalidInput(format!(
                         "Username {} is taken!",
@@ -236,16 +237,19 @@ pub async fn user_edit(
                 .execute(&mut *transaction)
                 .await?;
 
-                crate::util::report::censor_check(
-                    &*name.as_deref(),
-                    None,
-                    None,
-                    Some(crate::database::models::ids::UserId::from(
-                        user_id,
-                    )),
-                    "User edited with inappropriate name".to_string(),
-                    &mut transaction,
-                );
+                if let Some(name) = name {
+                    crate::util::report::censor_check(
+                        &*name,
+                        None,
+                        None,
+                        Some(crate::database::models::ids::UserId::from(
+                            user_id,
+                        )),
+                        "User edited with inappropriate name".to_string(),
+                        &mut transaction,
+                    )
+                    .await?;
+                }
             }
 
             if let Some(bio) = &new_user.bio {
@@ -261,16 +265,19 @@ pub async fn user_edit(
                 .execute(&mut *transaction)
                 .await?;
 
-                crate::util::report::censor_check(
-                    &*bio.as_deref(),
-                    None,
-                    None,
-                    Some(crate::database::models::ids::UserId::from(
-                        user_id,
-                    )),
-                    "User edited with inappropriate bio".to_string(),
-                    &mut transaction,
-                );
+                if let Some(bio) = bio {
+                    crate::util::report::censor_check(
+                        &*bio,
+                        None,
+                        None,
+                        Some(crate::database::models::ids::UserId::from(
+                            user_id,
+                        )),
+                        "User edited with inappropriate bio".to_string(),
+                        &mut transaction,
+                    )
+                    .await?;
+                }
             }
 
             if let Some(email) = &new_user.email {

--- a/src/routes/version_creation.rs
+++ b/src/routes/version_creation.rs
@@ -393,14 +393,18 @@ async fn version_create_inner(
     .insert_many(users, &mut *transaction)
     .await?;
 
-    crate::util::report::censor_check(
-        &*version_data.version_body,
-        None,
-        Some(models::ids::VersionId::from(version_id)),
-        None,
-        "Version created with inappropriate changelog".to_string(),
-        &mut *transaction,
-    );
+    if let Some(version_body) = version_data.version_body {
+        crate::util::report::censor_check(
+            &*version_body,
+            None,
+            Some(models::ids::VersionId::from(version_id)),
+            None,
+            "Version created with inappropriate changelog".to_string(),
+            &mut *transaction,
+        )
+        .await?;
+    }
+
     crate::util::report::censor_check(
         &*version_data.version_title,
         None,
@@ -408,7 +412,8 @@ async fn version_create_inner(
         None,
         "Version created with inappropriate name".to_string(),
         &mut *transaction,
-    );
+    )
+    .await?;
 
     let response = Version {
         id: builder.version_id.into(),

--- a/src/routes/version_creation.rs
+++ b/src/routes/version_creation.rs
@@ -393,6 +393,23 @@ async fn version_create_inner(
     .insert_many(users, &mut *transaction)
     .await?;
 
+    crate::util::report::censor_check(
+        &*version_data.version_body,
+        None,
+        Some(models::ids::VersionId::from(version_id)),
+        None,
+        "Version created with inappropriate changelog".to_string(),
+        &mut *transaction,
+    );
+    crate::util::report::censor_check(
+        &*version_data.version_title,
+        None,
+        Some(models::ids::VersionId::from(version_id)),
+        None,
+        "Version created with inappropriate name".to_string(),
+        &mut *transaction,
+    );
+
     let response = Version {
         id: builder.version_id.into(),
         project_id: builder.project_id.into(),

--- a/src/routes/versions.rs
+++ b/src/routes/versions.rs
@@ -9,6 +9,7 @@ use actix_web::{delete, get, patch, web, HttpRequest, HttpResponse};
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
 use validator::Validate;
+use crate::database::models::VersionId;
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct VersionListFilters {
@@ -247,6 +248,15 @@ pub async fn version_edit(
                 )
                 .execute(&mut *transaction)
                 .await?;
+
+                crate::util::report::censor_check(
+                    &*name,
+                    None,
+                    Some(VersionId::from(version_id)),
+                    None,
+                    "Version edited with inappropriate name".to_string(),
+                    &mut transaction,
+                );
             }
 
             if let Some(number) = &new_version.version_number {
@@ -463,6 +473,15 @@ pub async fn version_edit(
                 )
                 .execute(&mut *transaction)
                 .await?;
+
+                crate::util::report::censor_check(
+                    &*body,
+                    None,
+                    Some(VersionId::from(version_id)),
+                    None,
+                    "Version edited with inappropriate changelog".to_string(),
+                    &mut transaction,
+                );
             }
 
             if let Some(downloads) = &new_version.downloads {

--- a/src/routes/versions.rs
+++ b/src/routes/versions.rs
@@ -1,5 +1,6 @@
 use super::ApiError;
 use crate::database;
+use crate::database::models::VersionId;
 use crate::models;
 use crate::models::projects::{Dependency, Version};
 use crate::models::teams::Permissions;
@@ -9,7 +10,6 @@ use actix_web::{delete, get, patch, web, HttpRequest, HttpResponse};
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
 use validator::Validate;
-use crate::database::models::VersionId;
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct VersionListFilters {
@@ -256,7 +256,8 @@ pub async fn version_edit(
                     None,
                     "Version edited with inappropriate name".to_string(),
                     &mut transaction,
-                );
+                )
+                .await?;
             }
 
             if let Some(number) = &new_version.version_number {
@@ -481,7 +482,8 @@ pub async fn version_edit(
                     None,
                     "Version edited with inappropriate changelog".to_string(),
                     &mut transaction,
-                );
+                )
+                .await?;
             }
 
             if let Some(downloads) = &new_version.downloads {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -2,6 +2,7 @@ pub mod auth;
 pub mod env;
 pub mod ext;
 pub mod guards;
+pub mod report;
 pub mod routes;
 pub mod time_ser;
 pub mod validate;

--- a/src/util/report.rs
+++ b/src/util/report.rs
@@ -1,38 +1,38 @@
 use crate::database::models::categories::ReportType;
 use crate::database::models::report_item::Report;
 use crate::database::models::{
-    generate_report_id, ProjectId, UserId, VersionId,
+    generate_report_id, DatabaseError, ProjectId, UserId, VersionId,
 };
+use crate::models::users::DELETED_USER;
 use censor::Censor;
-use sqlx::{Postgres, Transaction};
 use time::OffsetDateTime;
 
-pub const CENSOR: Censor = Censor::Standard + Censor::Sex;
-
-pub fn censor_check(
+pub async fn censor_check(
     text: &str,
     project: Option<ProjectId>,
     version: Option<VersionId>,
     user: Option<UserId>,
     report_text: String,
-    transaction: &mut Transaction<Postgres>,
-) {
-    if CENSOR.check(text) {
+    mut transaction: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+) -> Result<(), DatabaseError> {
+    let censor = Censor::Standard + Censor::Sex;
+    if censor.check(text) {
         let report_type =
             ReportType::get_id("inappropriate", &mut *transaction)
                 .await?
                 .expect("No database entry for 'inappropriate' report type");
         Report {
-            id: generate_report_id(&mut *transaction).await?,
+            id: generate_report_id(&mut transaction).await?,
             report_type_id: report_type,
             project_id: project,
             version_id: version,
             user_id: user,
             body: report_text,
-            reporter: None,
+            reporter: UserId::from(DELETED_USER),
             created: OffsetDateTime::now_utc(),
         }
-        .insert(&mut *transaction)
+        .insert(&mut transaction)
         .await?;
     }
+    Ok(())
 }

--- a/src/util/report.rs
+++ b/src/util/report.rs
@@ -1,0 +1,38 @@
+use crate::database::models::categories::ReportType;
+use crate::database::models::report_item::Report;
+use crate::database::models::{
+    generate_report_id, ProjectId, UserId, VersionId,
+};
+use censor::Censor;
+use sqlx::{Postgres, Transaction};
+use time::OffsetDateTime;
+
+pub const CENSOR: Censor = Censor::Standard + Censor::Sex;
+
+pub fn censor_check(
+    text: &str,
+    project: Option<ProjectId>,
+    version: Option<VersionId>,
+    user: Option<UserId>,
+    report_text: String,
+    transaction: &mut Transaction<Postgres>,
+) {
+    if CENSOR.check(text) {
+        let report_type =
+            ReportType::get_id("inappropriate", &mut *transaction)
+                .await?
+                .expect("No database entry for 'inappropriate' report type");
+        Report {
+            id: generate_report_id(&mut *transaction).await?,
+            report_type_id: report_type,
+            project_id: project,
+            version_id: version,
+            user_id: user,
+            body: report_text,
+            reporter: None,
+            created: OffsetDateTime::now_utc(),
+        }
+        .insert(&mut *transaction)
+        .await?;
+    }
+}


### PR DESCRIPTION
This pull request does two things:
- Regenerate new IDs (project, version, user, etc.) with profanity
- Send reports to the moderators for new inappropriate content on the site

Resolves MOD-89