### PR TITLE
Fix HTTP status code 200 → 204 on `/version/{id}/file`

### DIFF
--- a/src/routes/version_creation.rs
+++ b/src/routes/version_creation.rs
@@ -629,7 +629,7 @@ async fn upload_file_to_version_inner(
         }
     }
 
-    Ok(HttpResponse::Ok().into())
+    Ok(HttpResponse::NoContent().body(""))
 }
 
 // This function is used for adding a file to a version, uploading the initial


### PR DESCRIPTION
The status code should be 204 because no body is sent. This causes errors in Omorphia's API handling function.

![Screen Shot 2022-07-07 at 9 09 45 PM](https://user-images.githubusercontent.com/44736536/177915280-ce2182ee-d6a7-4e27-8d92-cd6d76348add.png)