### PR TITLE
Add slug to searchable attributes and add project_id to facets

### DIFF
--- a/src/search/indexing/mod.rs
+++ b/src/search/indexing/mod.rs
@@ -210,7 +210,7 @@ const DEFAULT_DISPLAYED_ATTRIBUTES: &[&str] = &[
 ];
 
 const DEFAULT_SEARCHABLE_ATTRIBUTES: &[&str] =
-    &["title", "description", "author"];
+    &["title", "description", "author", "slug"];
 
 const DEFAULT_ATTRIBUTES_FOR_FACETING: &[&str] = &[
     "categories",
@@ -225,6 +225,7 @@ const DEFAULT_ATTRIBUTES_FOR_FACETING: &[&str] = &[
     "title",
     "date_created",
     "date_modified",
+    "project_id",
 ];
 
 const DEFAULT_SORTABLE_ATTRIBUTES: &[&str] =


### PR DESCRIPTION
Fixes #358

Adding project_id to the facets would allow the inclusion or exclusion of individual projects from search. For example, this would allow people to be able to exclude projects which they've already followed or are not interested in. My personal vision for this is to merge the [followed projects page](https://modrinth.com/settings/follows) into search itself.