### PR TITLE
fix slug colliding error not showing when editing project

### DIFF
--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -5047,6 +5047,26 @@
     },
     "query": "\n            SELECT id FROM categories\n            WHERE category = $1 AND project_type = $2\n            "
   },
+  "abf790170e3a807ffe8b3a188da620c89e6398f38ff066220fdadffe8e7481c1": {
+    "describe": {
+      "columns": [
+        {
+          "name": "exists",
+          "ordinal": 0,
+          "type_info": "Bool"
+        }
+      ],
+      "nullable": [
+        null
+      ],
+      "parameters": {
+        "Left": [
+          "Text"
+        ]
+      }
+    },
+    "query": "\n                      SELECT EXISTS(SELECT 1 FROM mods WHERE slug = LOWER($1))\n                      "
+  },
   "ac2d17b7d7147b14f072c15ffa214c14f32f27ffa6a3c2b2a5f80f3ad49ca5e9": {
     "describe": {
       "columns": [

--- a/src/routes/projects.rs
+++ b/src/routes/projects.rs
@@ -2,6 +2,7 @@ use crate::database;
 use crate::database::models::notification_item::NotificationBuilder;
 use crate::file_hosting::FileHost;
 use crate::models;
+use crate::models::ids::base62_impl::parse_base62;
 use crate::models::projects::{
     DonationLink, Project, ProjectId, ProjectStatus, SearchRequest, SideType,
 };
@@ -871,6 +872,26 @@ pub async fn project_edit(
                         "You do not have the permissions to edit the slug of this project!"
                             .to_string(),
                     ));
+                }
+
+                let slug_project_id_option: Option<u64> =
+                    parse_base62(slug).ok();
+                if let Some(slug_project_id) = slug_project_id_option {
+                    let results = sqlx::query!(
+                        "
+                        SELECT EXISTS(SELECT 1 FROM mods WHERE id=$1)
+                        ",
+                        slug_project_id as i64
+                    )
+                    .fetch_one(&mut *transaction)
+                    .await?;
+
+                    if results.exists.unwrap_or(true) {
+                        return Err(ApiError::InvalidInput(
+                            "Slug collides with other project's id!"
+                                .to_string(),
+                        ));
+                    }
                 }
 
                 {

--- a/src/routes/projects.rs
+++ b/src/routes/projects.rs
@@ -872,20 +872,23 @@ pub async fn project_edit(
                             .to_string(),
                     ));
                 }
-                
+
                 {
-                  let results = sqlx::query!(
-                      "
+                    let results = sqlx::query!(
+                        "
                       SELECT EXISTS(SELECT 1 FROM mods WHERE slug = LOWER($1))
                       ",
-                      slug
-                  )
-                  .fetch_one(&mut *transaction)
-                  .await?;
+                        slug
+                    )
+                    .fetch_one(&mut *transaction)
+                    .await?;
 
-                  if results.exists.unwrap_or(true) {
-                      return Err(ApiError::InvalidInput("Slug collides with other project's id!".to_string()));
-                  }
+                    if results.exists.unwrap_or(true) {
+                        return Err(ApiError::InvalidInput(
+                            "Slug collides with other project's id!"
+                                .to_string(),
+                        ));
+                    }
                 }
 
                 sqlx::query!(


### PR DESCRIPTION
Closes #487 

This PR aligns with the project_creation file, that it also checks on the slug.
The code right before this is never ran when editing the slug to the same as another project.

So I added the extra DB query/check to check solely on the slug.

As seen on the video this now works, displaying a nicer error to the user.


https://user-images.githubusercontent.com/32039051/217532994-bb31ecf6-eb81-4d90-b9a9-ab1b12dabe4b.mov

