### PR TITLE
Validate minimum size for icon image

### DIFF
--- a/src/routes/projects.rs
+++ b/src/routes/projects.rs
@@ -1655,6 +1655,15 @@ pub async fn project_icon_edit(
         )
         .await?;
 
+        let (image_width, image_height) =
+            crate::util::img::get_image_size(&bytes)?;
+
+        if image_width < 100 || image_height < 100 {
+            return Err(ApiError::InvalidInput(
+                "Icon must meet the minimum 100x100px requirements".to_string(),
+            ));
+        }
+
         let color = crate::util::img::get_color_from_img(&bytes)?;
 
         let hash = sha1::Sha1::from(&bytes).hexdigest();

--- a/src/util/img.rs
+++ b/src/util/img.rs
@@ -18,3 +18,8 @@ pub fn get_color_from_img(data: &[u8]) -> Result<Option<u32>, ImageError> {
 
     Ok(color)
 }
+
+pub fn get_image_size(data: &[u8]) -> Result<(u32, u32), ImageError> {
+    let image = &image::load_from_memory(data)?;
+    Ok((image.width(), image.height()))
+}


### PR DESCRIPTION
Should a maximum size also be set?
Should it always enforce 1:1 ratios?
PolyMC mentioned they saw a 1920x1920 image once. (Lots of unnecessary data to store)

This PR adds the minimum icon size validation to the icon patch request.
Alongside it, it also adds a small image utility function that extracts the width, and height from any image.

_Note:
Next step would need to be a PR in knossos, that removes the image if the icon update failed.
Not sure I will personally do that, however I will open an issue once this is merged to track it._

**Media:**

https://user-images.githubusercontent.com/32039051/218141975-dadbe5b3-131b-43aa-87ff-ff33e4a4e69c.mov



Closes: #216