### PR TITLE
Fix version name can be empty string

### DIFF
--- a/src/routes/project_creation.rs
+++ b/src/routes/project_creation.rs
@@ -140,7 +140,10 @@ fn default_requested_status() -> ProjectStatus {
 
 #[derive(Serialize, Deserialize, Validate, Clone)]
 struct ProjectCreateData {
-    #[validate(length(min = 3, max = 64))]
+    #[validate(
+        length(min = 3, max = 64),
+        custom(function = "crate::util::validate::validate_name")
+    )]
     #[serde(alias = "mod_name")]
     /// The title or name of the project.
     pub title: String,

--- a/src/routes/projects.rs
+++ b/src/routes/projects.rs
@@ -294,7 +294,10 @@ pub async fn dependency_list(
 /// A project returned from the API
 #[derive(Serialize, Deserialize, Validate)]
 pub struct EditProject {
-    #[validate(length(min = 3, max = 64))]
+    #[validate(
+        length(min = 3, max = 64),
+        custom(function = "crate::util::validate::validate_name")
+    )]
     pub title: Option<String>,
     #[validate(length(min = 3, max = 256))]
     pub description: Option<String>,
@@ -446,7 +449,7 @@ pub async fn project_edit(
                     SET title = $1
                     WHERE (id = $2)
                     ",
-                    title,
+                    title.trim(),
                     id as database::models::ids::ProjectId,
                 )
                 .execute(&mut *transaction)

--- a/src/routes/version_creation.rs
+++ b/src/routes/version_creation.rs
@@ -41,7 +41,10 @@ pub struct InitialVersionData {
         regex = "crate::util::validate::RE_URL_SAFE"
     )]
     pub version_number: String,
-    #[validate(length(min = 1, max = 64))]
+    #[validate(
+        length(min = 1, max = 64),
+        custom(function = "crate::util::validate::validate_name")
+    )]
     #[serde(alias = "name")]
     pub version_title: String,
     #[validate(length(max = 65536))]
@@ -275,7 +278,7 @@ async fn version_create_inner(
                         file_name: None,
                     })
                     .collect::<Vec<_>>();
-
+                println!("{}", version_create_data.version_title.clone());
                 version_builder = Some(VersionBuilder {
                     version_id: version_id.into(),
                     project_id,

--- a/src/routes/version_creation.rs
+++ b/src/routes/version_creation.rs
@@ -278,6 +278,7 @@ async fn version_create_inner(
                         file_name: None,
                     })
                     .collect::<Vec<_>>();
+
                 version_builder = Some(VersionBuilder {
                     version_id: version_id.into(),
                     project_id,

--- a/src/routes/version_creation.rs
+++ b/src/routes/version_creation.rs
@@ -278,7 +278,6 @@ async fn version_create_inner(
                         file_name: None,
                     })
                     .collect::<Vec<_>>();
-                println!("{}", version_create_data.version_title.clone());
                 version_builder = Some(VersionBuilder {
                     version_id: version_id.into(),
                     project_id,

--- a/src/routes/versions.rs
+++ b/src/routes/versions.rs
@@ -207,7 +207,10 @@ pub async fn version_get(
 
 #[derive(Serialize, Deserialize, Validate)]
 pub struct EditVersion {
-    #[validate(length(min = 1, max = 64))]
+    #[validate(
+        length(min = 1, max = 64),
+        custom(function = "crate::util::validate::validate_name")
+    )]
     pub name: Option<String>,
     #[validate(
         length(min = 1, max = 32),
@@ -300,7 +303,7 @@ pub async fn version_edit(
                     SET name = $1
                     WHERE (id = $2)
                     ",
-                    name,
+                    name.trim(),
                     id as database::models::ids::VersionId,
                 )
                 .execute(&mut *transaction)

--- a/src/util/validate.rs
+++ b/src/util/validate.rs
@@ -97,3 +97,13 @@ pub fn validate_url(value: &str) -> Result<(), validator::ValidationError> {
 
     Ok(())
 }
+
+pub fn validate_name(value: &str) -> Result<(), validator::ValidationError> {
+    if value.trim().is_empty() {
+        return Err(validator::ValidationError::new(
+            "Name can not contain only whitespace.",
+        ));
+    }
+
+    Ok(())
+}

--- a/src/util/validate.rs
+++ b/src/util/validate.rs
@@ -101,7 +101,7 @@ pub fn validate_url(value: &str) -> Result<(), validator::ValidationError> {
 pub fn validate_name(value: &str) -> Result<(), validator::ValidationError> {
     if value.trim().is_empty() {
         return Err(validator::ValidationError::new(
-            "Name can not contain only whitespace.",
+            "Name cannot contain only whitespace.",
         ));
     }
 

--- a/src/util/validate.rs
+++ b/src/util/validate.rs
@@ -107,3 +107,20 @@ pub fn validate_name(value: &str) -> Result<(), validator::ValidationError> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_name_with_valid_input() {
+        let result = validate_name("My Test mod");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_name_with_invalid_input_returns_error() {
+        let result = validate_name("  ");
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
**Description:**
Validates the version name, to check if trimming the name results in the string being empty.
Also trims the name on insert, to remove whitespace before and after name.

**Media:**

https://user-images.githubusercontent.com/32039051/218306547-d29a6ef7-9211-401c-bc9c-8e4c83617a1f.mov

Closes: #169 