### PR TITLE
chore(validate): update error description to space actual error

### DIFF
--- a/src/util/validate.rs
+++ b/src/util/validate.rs
@@ -42,12 +42,12 @@ pub fn validation_errors_to_string(
                     if let Some(error) = errors.get(0) {
                         if let Some(adder) = adder {
                             output.push_str(&format!(
-                                "Field {} {} failed validation with error {}",
+                                "Field {} {} failed validation with error: {}",
                                 field, adder, error.code
                             ));
                         } else {
                             output.push_str(&format!(
-                                "Field {} failed validation with error {}",
+                                "Field {} failed validation with error: {}",
                                 field, error.code
                             ));
                         }


### PR DESCRIPTION
Before the error description would be something like this:
```json
{
    "error": "invalid_input",
    "description": "Error while validating input: Field name failed validation with error Name can not contain only whitespace."
}
```

It's hard to see which error is what, since this is 3 errors in the same line.
I simply added a colon to space it out, so it's more intuitive where the last error begins, just like the colon between the first and second error.
```json
{
    "error": "invalid_input",
    "description": "Error while validating input: Field name failed validation with error: Name can not contain only whitespace."
}
```