### PR TITLE
update project index to use approval date if set

### DIFF
--- a/src/search/indexing/local_import.rs
+++ b/src/search/indexing/local_import.rs
@@ -79,7 +79,7 @@ pub async fn index_local(
                         downloads: m.downloads,
                         icon_url: m.icon_url.unwrap_or_default(),
                         author: m.username,
-                        date_created: m.published,
+                        date_created: m.approved.unwrap_or(m.published),
                         created_timestamp: m.approved.unwrap_or(m.published).timestamp(),
                         date_modified: m.updated,
                         modified_timestamp: m.updated.timestamp(),


### PR DESCRIPTION
**Description:**
I saw the created_timestamp is using approved if set, else published date, but the actual `date_created` was not, which is the one that is used for searching by approval date.

_The update should automatically propgate to all projects, after a re-index (which occurs every hour if I understand it correctly)_

**Media:**
As seen on the image, the `created_date` in meilisearch is the approved date, and not the published date. (Published being when the project was created, and approved being when it was actually published to search/approved)
![image](https://user-images.githubusercontent.com/32039051/218971368-2b539ffc-5e35-49a5-9df9-b7f462be182e.png)

Closes: #446