### PR TITLE
Added Paper Plugins support

### DIFF
--- a/src/validate/plugin.rs
+++ b/src/validate/plugin.rs
@@ -32,11 +32,14 @@ impl super::Validator for PluginYmlValidator {
         &self,
         archive: &mut ZipArchive<Cursor<bytes::Bytes>>,
     ) -> Result<ValidationResult, ValidationError> {
-        if archive.by_name("plugin.yml").is_err() {
+        if !archive
+            .file_names()
+            .any(|name| name == "plugin.yml" || name == "paper-plugin.yml")
+        {
             return Ok(ValidationResult::Warning(
-                "No plugin.yml present for plugin file.",
+                "No plugin.yml or paper-plugin.yml present for plugin file.",
             ));
-        }
+        };
 
         Ok(ValidationResult::Pass)
     }


### PR DESCRIPTION
Currently, if you want to upload a Paper plugin to Modrinth, this error occurs because the filter only considers plugins created through a `plugin.yml` file.
![](https://cdn.discordapp.com/attachments/783153806531100673/1137804688574648340/image.png)
A few months ago Paper implemented the new concept of [Paper exclusive plugins](https://docs.papermc.io/paper/dev/getting-started/paper-plugins), which are created through a `paper-plugin.yml` file. This pull request allows these plugins to be uploaded without any problem