### PR TITLE
Allow BungeeCord plugins that use bungee.yml

### DIFF
--- a/src/validate/plugin.rs
+++ b/src/validate/plugin.rs
@@ -18,7 +18,7 @@ impl super::Validator for PluginYmlValidator {
             "bukkit",
             "spigot",
             "paper",
-            "purpur"
+            "purpur",
         ]
     }
 

--- a/src/validate/plugin.rs
+++ b/src/validate/plugin.rs
@@ -18,9 +18,7 @@ impl super::Validator for PluginYmlValidator {
             "bukkit",
             "spigot",
             "paper",
-            "purpur",
-            "bungeecord",
-            "waterfall",
+            "purpur"
         ]
     }
 
@@ -68,11 +66,14 @@ impl super::Validator for BungeeCordValidator {
         &self,
         archive: &mut ZipArchive<Cursor<bytes::Bytes>>,
     ) -> Result<ValidationResult, ValidationError> {
-        if archive.by_name("bungee.yml").is_err() {
+        if !archive
+            .file_names()
+            .any(|name| name == "plugin.yml" || name == "bungee.yml")
+        {
             return Ok(ValidationResult::Warning(
-                "No bungee.yml present for plugin file.",
+                "No plugin.yml or bungee.yml present for plugin file.",
             ));
-        }
+        };
 
         Ok(ValidationResult::Pass)
     }


### PR DESCRIPTION
First time Rust user here. I'm under the impression that all of the `VALIDATORS` in rust.rs are tested to see if they match the given primary file upload? It seems like PluginYmlValidator was matching for bungeecord/waterfall but then subsequently denying the upload because it doesn't cover the bungeecord usage of `bungee.yml` as described in #687.

bungeecord/waterfall was removed as a supported platform of PluginYmlValidator, as there is already BungeeCordValidator. I believe this should fix the issue.
Also, support for `plugin.yml` was added to BungeeCordValidator (although that wasn't the current source of this issue).

As discussed on Discord, I haven't tested this PR.

Closes #687