### PR TITLE
Don't show processing projects in thread message inbox

### DIFF
--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -536,6 +536,18 @@
     },
     "query": "\n        SELECT EXISTS(SELECT 1 FROM mod_follows mf WHERE mf.follower_id = $1 AND mf.mod_id = $2)\n        "
   },
+  "10279b5a8383ba8e286f1bfb9a486e3f8b362c46cfc2647c90a83a10e5329569": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Int8"
+        ]
+      }
+    },
+    "query": "\n                        UPDATE threads\n                        SET show_in_mod_inbox = FALSE\n                        WHERE id = $1\n                        "
+  },
   "1209ffc1ffbea89f7060573275dc7325ac4d7b4885b6c1d1ec92998e6012e455": {
     "describe": {
       "columns": [],
@@ -2130,26 +2142,6 @@
       }
     },
     "query": "\n                    UPDATE versions\n                    SET version_number = $1\n                    WHERE (id = $2)\n                    "
-  },
-  "5586d60c8f3d58a31e6635ffb3cb30bac389bf21b190dfd1e64a44e837f3879c": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id",
-          "ordinal": 0,
-          "type_info": "Int8"
-        }
-      ],
-      "nullable": [
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "Text"
-        ]
-      }
-    },
-    "query": "\n                    SELECT id FROM mods\n                    WHERE status = $1 AND queued < NOW() - INTERVAL '40 hours'\n                    ORDER BY updated ASC\n                    "
   },
   "5627b3516fc7c3799154098a663b1586aac11b2dc736810f06630ee5d8a54946": {
     "describe": {

--- a/src/routes/v2/projects.rs
+++ b/src/routes/v2/projects.rs
@@ -493,6 +493,17 @@ pub async fn project_edit(
                     )
                     .execute(&mut *transaction)
                     .await?;
+
+                    sqlx::query!(
+                        "
+                        UPDATE threads
+                        SET show_in_mod_inbox = FALSE
+                        WHERE id = $1
+                        ",
+                        project_item.thread_id as database::models::ids::ThreadId,
+                    )
+                    .execute(&mut *transaction)
+                    .await?;
                 }
 
                 if status.is_approved() && !project_item.inner.status.is_approved() {
@@ -543,7 +554,11 @@ pub async fn project_edit(
                             Some(
                                 format!(
                                     "**[{}]({}/user/{})** changed project status from **{}** to **{}**",
-                                    user.username, dotenvy::var("SITE_URL")?, user.username, &project_item.inner.status, status
+                                    user.username,
+                                    dotenvy::var("SITE_URL")?,
+                                    user.username,
+                                    &project_item.inner.status.as_friendly_str(),
+                                    status.as_friendly_str(),
                                 )
                                 .to_string(),
                             ),


### PR DESCRIPTION
They already show up in the Review tab, so, no reason to also have them in the Messages tab