### PR TITLE
hotfix maven version filtering code not working when the actual version number contains a dash

### DIFF
--- a/src/routes/maven.rs
+++ b/src/routes/maven.rs
@@ -191,7 +191,7 @@ async fn find_version(
         .partition::<Vec<_>, _>(|el| db_loaders.contains(el));
 
     let matched = all_versions
-        .into_iter()
+        .iter()
         .filter(|x| {
             let mut bool = x.inner.version_number == vnumber;
 
@@ -206,7 +206,7 @@ async fn find_version(
         })
         .collect::<Vec<_>>();
 
-    Ok(matched.get(0).cloned())
+    Ok(matched.get(0).or_else(|| exact_matches.get(0)).copied().cloned())
 }
 
 fn find_file<'a>(


### PR DESCRIPTION
Fixes links like `https://api.modrinth.com/maven/maven/modrinth/moonlight/1.20-2.8.44/moonlight-1.20-2.8.44.pom` not working anymore™