### PR TITLE
Batch inserts [MOD-555]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1272,6 +1272,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-new"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3418329ca0ad70234b9735dc4ceed10af4df60eff9c8e7b06cb5e520d92c3535"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2246,6 +2257,7 @@ dependencies = [
  "color-thief",
  "dashmap",
  "deadpool-redis",
+ "derive-new",
  "dotenvy",
  "env_logger",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,5 +93,7 @@ woothee = "0.13.0"
 
 lettre = "0.10.4"
 
+derive-new = "0.5.9"
+
 [dev-dependencies]
 actix-http = "3.4.0"

--- a/src/clickhouse/mod.rs
+++ b/src/clickhouse/mod.rs
@@ -6,8 +6,12 @@ mod fetch;
 pub use fetch::*;
 
 pub async fn init_client() -> clickhouse::error::Result<clickhouse::Client> {
-    let database = dotenvy::var("CLICKHOUSE_DATABASE").unwrap();
+    init_client_with_database(&dotenvy::var("CLICKHOUSE_DATABASE").unwrap()).await
+}
 
+pub async fn init_client_with_database(
+    database: &str,
+) -> clickhouse::error::Result<clickhouse::Client> {
     let client = {
         let mut http_connector = HttpConnector::new();
         http_connector.enforce_http(false); // allow https URLs

--- a/src/database/models/collection_item.rs
+++ b/src/database/models/collection_item.rs
@@ -1,12 +1,9 @@
-use std::iter;
-
 use super::ids::*;
 use crate::database::models;
 use crate::database::models::DatabaseError;
 use crate::database::redis::RedisPool;
 use crate::models::collections::CollectionStatus;
 use chrono::{DateTime, Utc};
-use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
 const COLLECTIONS_NAMESPACE: &str = "collections";

--- a/src/database/models/collection_item.rs
+++ b/src/database/models/collection_item.rs
@@ -1,9 +1,12 @@
+use std::iter;
+
 use super::ids::*;
 use crate::database::models;
 use crate::database::models::DatabaseError;
 use crate::database::redis::RedisPool;
 use crate::models::collections::CollectionStatus;
 use chrono::{DateTime, Utc};
+use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
 const COLLECTIONS_NAMESPACE: &str = "collections";
@@ -81,19 +84,19 @@ impl Collection {
         .execute(&mut *transaction)
         .await?;
 
-        for project_id in self.projects.iter() {
-            sqlx::query!(
-                "
-                    INSERT INTO collections_mods (collection_id, mod_id)
-                    VALUES ($1, $2)
-                    ON CONFLICT DO NOTHING
-                ",
-                self.id as CollectionId,
-                *project_id as ProjectId,
-            )
-            .execute(&mut *transaction)
-            .await?;
-        }
+        let (collection_ids, project_ids): (Vec<_>, Vec<_>) =
+            self.projects.iter().map(|p| (self.id.0, p.0)).unzip();
+        sqlx::query!(
+            "
+                INSERT INTO collections_mods (collection_id, mod_id)
+                SELECT * FROM UNNEST($1::bigint[], $2::bigint[])
+                ON CONFLICT DO NOTHING
+            ",
+            &collection_ids[..],
+            &project_ids[..],
+        )
+        .execute(&mut *transaction)
+        .await?;
 
         Ok(())
     }

--- a/src/database/models/thread_item.rs
+++ b/src/database/models/thread_item.rs
@@ -94,11 +94,11 @@ impl ThreadBuilder {
             self.members.iter().map(|m| (thread_id.0, m.0)).unzip();
         sqlx::query!(
             "
-                INSERT INTO threads_members (
-                    thread_id, user_id
-                )
-                SELECT * FROM UNNEST ($1::int8[], $2::int8[])
-                ",
+            INSERT INTO threads_members (
+                thread_id, user_id
+            )
+            SELECT * FROM UNNEST ($1::int8[], $2::int8[])
+            ",
             &thread_ids[..],
             &members[..],
         )

--- a/src/database/models/thread_item.rs
+++ b/src/database/models/thread_item.rs
@@ -1,5 +1,3 @@
-use std::os::unix::thread;
-
 use super::ids::*;
 use crate::database::models::DatabaseError;
 use crate::models::threads::{MessageBody, ThreadType};

--- a/src/database/models/thread_item.rs
+++ b/src/database/models/thread_item.rs
@@ -1,3 +1,5 @@
+use std::os::unix::thread;
+
 use super::ids::*;
 use crate::database::models::DatabaseError;
 use crate::models::threads::{MessageBody, ThreadType};
@@ -90,22 +92,20 @@ impl ThreadBuilder {
         .execute(&mut *transaction)
         .await?;
 
-        for member in &self.members {
-            sqlx::query!(
-                "
+        let (thread_ids, members): (Vec<_>, Vec<_>) =
+            self.members.iter().map(|m| (thread_id.0, m.0)).unzip();
+        sqlx::query!(
+            "
                 INSERT INTO threads_members (
                     thread_id, user_id
                 )
-                VALUES (
-                    $1, $2
-                )
+                SELECT * FROM UNNEST ($1::int8[], $2::int8[])
                 ",
-                thread_id as ThreadId,
-                *member as UserId,
-            )
-            .execute(&mut *transaction)
-            .await?;
-        }
+            &thread_ids[..],
+            &members[..],
+        )
+        .execute(&mut *transaction)
+        .await?;
 
         Ok(thread_id)
     }

--- a/src/database/models/version_item.rs
+++ b/src/database/models/version_item.rs
@@ -73,7 +73,7 @@ impl DependencyBuilder {
         sqlx::query!(
             "
             INSERT INTO dependencies (dependent_id, dependency_type, dependency_id, mod_dependency_id, dependency_file_name)
-            SELECT * FROM UNNEST ($1::bigint[], $2::varchar[255][], $3::bigint[], $4::bigint[], $5::varchar[1024][])
+            SELECT * FROM UNNEST ($1::bigint[], $2::varchar[], $3::bigint[], $4::bigint[], $5::varchar[])
             ",
             &version_ids[..],
             &dependency_types[..],
@@ -96,8 +96,8 @@ impl DependencyBuilder {
         } else if let Some(version_id) = self.version_id {
             sqlx::query!(
                 "
-                        SELECT mod_id FROM versions WHERE id = $1
-                        ",
+                SELECT mod_id FROM versions WHERE id = $1
+                ",
                 version_id as VersionId,
             )
             .fetch_optional(&mut *transaction)
@@ -152,7 +152,7 @@ impl VersionFileBuilder {
         sqlx::query!(
             "
             INSERT INTO files (id, version_id, url, filename, is_primary, size, file_type)
-            SELECT * FROM UNNEST($1::bigint[], $2::bigint[], $3::varchar[2048], $4::varchar[2048], $5::bool[], $6::integer[], $7::varchar[128])
+            SELECT * FROM UNNEST($1::bigint[], $2::bigint[], $3::varchar[], $4::varchar[], $5::bool[], $6::integer[], $7::varchar[])
             ",
             &file_ids[..],
             &version_ids[..],
@@ -176,7 +176,7 @@ impl VersionFileBuilder {
         sqlx::query!(
             "
             INSERT INTO hashes (file_id, algorithm, hash)
-            SELECT * FROM UNNEST($1::bigint[], $2::varchar[255], $3::bytea[])
+            SELECT * FROM UNNEST($1::bigint[], $2::varchar[], $3::bytea[])
             ",
             &file_ids[..],
             &algorithms[..],

--- a/src/database/models/version_item.rs
+++ b/src/database/models/version_item.rs
@@ -39,18 +39,65 @@ pub struct DependencyBuilder {
 }
 
 impl DependencyBuilder {
-    pub async fn insert(
-        self,
+    pub async fn insert_many(
+        builders: Vec<Self>,
         version_id: VersionId,
         transaction: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     ) -> Result<(), DatabaseError> {
-        let project_id = if let Some(project_id) = self.project_id {
+        let mut project_ids = Vec::new();
+        for dependency in builders.iter() {
+            project_ids.push(
+                dependency
+                    .try_get_project_id(transaction)
+                    .await?
+                    .map(|id| id.0),
+            );
+        }
+
+        let (version_ids, dependency_types, dependency_ids, filenames): (
+            Vec<_>,
+            Vec<_>,
+            Vec<_>,
+            Vec<_>,
+        ) = builders
+            .into_iter()
+            .map(|d| {
+                (
+                    version_id.0,
+                    d.dependency_type,
+                    d.version_id.map(|v| v.0),
+                    d.file_name,
+                )
+            })
+            .multiunzip();
+        sqlx::query!(
+            "
+            INSERT INTO dependencies (dependent_id, dependency_type, dependency_id, mod_dependency_id, dependency_file_name)
+            SELECT * FROM UNNEST ($1::bigint[], $2::varchar[255][], $3::bigint[], $4::bigint[], $5::varchar[1024][])
+            ",
+            &version_ids[..],
+            &dependency_types[..],
+            &dependency_ids[..] as &[Option<i64>],
+            &project_ids[..] as &[Option<i64>],
+            &filenames[..] as &[Option<String>],
+        )
+        .execute(&mut *transaction)
+        .await?;
+
+        Ok(())
+    }
+
+    async fn try_get_project_id(
+        &self,
+        transaction: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    ) -> Result<Option<ProjectId>, DatabaseError> {
+        Ok(if let Some(project_id) = self.project_id {
             Some(project_id)
         } else if let Some(version_id) = self.version_id {
             sqlx::query!(
                 "
-                SELECT mod_id FROM versions WHERE id = $1
-                ",
+                        SELECT mod_id FROM versions WHERE id = $1
+                        ",
                 version_id as VersionId,
             )
             .fetch_optional(&mut *transaction)
@@ -58,23 +105,7 @@ impl DependencyBuilder {
             .map(|x| ProjectId(x.mod_id))
         } else {
             None
-        };
-
-        sqlx::query!(
-            "
-            INSERT INTO dependencies (dependent_id, dependency_type, dependency_id, mod_dependency_id, dependency_file_name)
-            VALUES ($1, $2, $3, $4, $5)
-            ",
-            version_id as VersionId,
-            self.dependency_type,
-            self.version_id.map(|x| x.0),
-            project_id.map(|x| x.0),
-            self.file_name,
-        )
-        .execute(&mut *transaction)
-        .await?;
-
-        Ok(())
+        })
     }
 }
 
@@ -89,42 +120,70 @@ pub struct VersionFileBuilder {
 }
 
 impl VersionFileBuilder {
-    pub async fn insert(
-        self,
+    pub async fn insert_many(
+        version_files: Vec<Self>,
         version_id: VersionId,
         transaction: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     ) -> Result<FileId, DatabaseError> {
         let file_id = generate_file_id(&mut *transaction).await?;
 
+        let (file_ids, version_ids, urls, filenames, primary, sizes, file_types): (
+            Vec<_>,
+            Vec<_>,
+            Vec<_>,
+            Vec<_>,
+            Vec<_>,
+            Vec<_>,
+            Vec<_>,
+        ) = version_files
+            .iter()
+            .map(|f| {
+                (
+                    file_id.0,
+                    version_id.0,
+                    f.url.clone(),
+                    f.filename.clone(),
+                    f.primary,
+                    f.size as i32,
+                    f.file_type.map(|x| x.to_string()),
+                )
+            })
+            .multiunzip();
         sqlx::query!(
             "
             INSERT INTO files (id, version_id, url, filename, is_primary, size, file_type)
-            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            SELECT * FROM UNNEST($1::bigint[], $2::bigint[], $3::varchar[2048], $4::varchar[2048], $5::bool[], $6::integer[], $7::varchar[128])
             ",
-            file_id as FileId,
-            version_id as VersionId,
-            self.url,
-            self.filename,
-            self.primary,
-            self.size as i32,
-            self.file_type.map(|x| x.as_str()),
+            &file_ids[..],
+            &version_ids[..],
+            &urls[..],
+            &filenames[..],
+            &primary[..],
+            &sizes[..],
+            &file_types[..] as &[Option<String>],
         )
         .execute(&mut *transaction)
         .await?;
 
-        for hash in self.hashes {
-            sqlx::query!(
-                "
-                INSERT INTO hashes (file_id, algorithm, hash)
-                VALUES ($1, $2, $3)
-                ",
-                file_id as FileId,
-                hash.algorithm,
-                hash.hash,
-            )
-            .execute(&mut *transaction)
-            .await?;
-        }
+        let (file_ids, algorithms, hashes): (Vec<_>, Vec<_>, Vec<_>) = version_files
+            .into_iter()
+            .flat_map(|f| {
+                f.hashes
+                    .into_iter()
+                    .map(|h| (file_id.0, h.algorithm, h.hash))
+            })
+            .multiunzip();
+        sqlx::query!(
+            "
+            INSERT INTO hashes (file_id, algorithm, hash)
+            SELECT * FROM UNNEST($1::bigint[], $2::varchar[255], $3::bytea[])
+            ",
+            &file_ids[..],
+            &algorithms[..],
+            &hashes[..],
+        )
+        .execute(&mut *transaction)
+        .await?;
 
         Ok(file_id)
     }
@@ -170,39 +229,43 @@ impl VersionBuilder {
         .execute(&mut *transaction)
         .await?;
 
-        for file in self.files {
-            file.insert(self.version_id, transaction).await?;
-        }
+        let VersionBuilder {
+            dependencies,
+            loaders,
+            game_versions,
+            files,
+            version_id,
+            ..
+        } = self;
+        VersionFileBuilder::insert_many(files, self.version_id, transaction).await?;
 
-        for dependency in self.dependencies {
-            dependency.insert(self.version_id, transaction).await?;
-        }
+        DependencyBuilder::insert_many(dependencies, self.version_id, transaction).await?;
 
-        for loader in self.loaders.clone() {
-            sqlx::query!(
-                "
-                INSERT INTO loaders_versions (loader_id, version_id)
-                VALUES ($1, $2)
-                ",
-                loader as LoaderId,
-                self.version_id as VersionId,
-            )
-            .execute(&mut *transaction)
-            .await?;
-        }
+        let (loader_ids, version_ids): (Vec<_>, Vec<_>) =
+            loaders.iter().map(|l| (l.0, version_id.0)).unzip();
+        sqlx::query!(
+            "
+            INSERT INTO loaders_versions (loader_id, version_id)
+            SELECT * FROM UNNEST($1::integer[], $2::bigint[])
+            ",
+            &loader_ids[..],
+            &version_ids[..],
+        )
+        .execute(&mut *transaction)
+        .await?;
 
-        for game_version in self.game_versions.clone() {
-            sqlx::query!(
-                "
-                INSERT INTO game_versions_versions (game_version_id, joining_version_id)
-                VALUES ($1, $2)
-                ",
-                game_version as GameVersionId,
-                self.version_id as VersionId,
-            )
-            .execute(&mut *transaction)
-            .await?;
-        }
+        let (game_version_ids, version_ids): (Vec<_>, Vec<_>) =
+            game_versions.iter().map(|v| (v.0, version_id.0)).unzip();
+        sqlx::query!(
+            "
+            INSERT INTO game_versions_versions (game_version_id, joining_version_id)
+            SELECT * FROM UNNEST($1::integer[], $2::bigint[])
+            ",
+            &game_version_ids[..],
+            &version_ids[..],
+        )
+        .execute(&mut *transaction)
+        .await?;
 
         Ok(self.version_id)
     }

--- a/src/queue/analytics/tests.rs
+++ b/src/queue/analytics/tests.rs
@@ -1,0 +1,128 @@
+use futures::Future;
+use uuid::Uuid;
+
+use super::*;
+use crate::clickhouse::init_client_with_database;
+use std::net::Ipv6Addr;
+
+#[tokio::test]
+async fn test_indexing() {
+    with_test_clickhouse_db(|clickhouse_client| async move {
+        let analytics = AnalyticsQueue::new();
+
+        analytics.add_download(get_default_download());
+        analytics.add_playtime(get_default_playtime());
+        analytics.add_view(get_default_views());
+
+        analytics.index(clickhouse_client.clone()).await.unwrap();
+        assert_table_counts(&clickhouse_client, 1, 1, 1).await;
+
+        analytics.index(clickhouse_client.clone()).await.unwrap();
+        assert_table_counts(&clickhouse_client, 1, 1, 1).await;
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn can_insert_many_downloads() {
+    with_test_clickhouse_db(|clickhouse_client| async move {
+        let analytics = AnalyticsQueue::new();
+        let n_downloads = 100_000;
+
+        for _ in 0..n_downloads {
+            analytics.add_download(get_default_download());
+        }
+
+        analytics.index(clickhouse_client.clone()).await.unwrap();
+        assert_table_count(DOWNLOADS_TABLENAME, &clickhouse_client, n_downloads).await;
+    })
+    .await;
+}
+
+async fn assert_table_counts(
+    client: &clickhouse::Client,
+    downloads: u64,
+    playtimes: u64,
+    views: u64,
+) {
+    assert_table_count(DOWNLOADS_TABLENAME, client, downloads).await;
+    assert_table_count(PLAYTIME_TABLENAME, client, playtimes).await;
+    assert_table_count(VIEWS_TABLENAME, client, views).await;
+}
+
+async fn assert_table_count(table_name: &str, client: &clickhouse::Client, expected_count: u64) {
+    let count = client
+        .query(&format!("SELECT COUNT(*) from {table_name}"))
+        .fetch_one::<u64>()
+        .await
+        .unwrap();
+    assert_eq!(expected_count, count);
+}
+
+async fn with_test_clickhouse_db<Fut>(f: impl FnOnce(clickhouse::Client) -> Fut)
+where
+    Fut: Future<Output = ()>,
+{
+    let db_name = format!("test_{}", uuid::Uuid::new_v4().as_simple());
+    println!("Clickhouse test db: {}", db_name);
+    let clickhouse_client = init_client_with_database(&db_name)
+        .await
+        .expect("A real clickhouse instance should be running locally");
+
+    f(clickhouse_client.clone()).await;
+
+    clickhouse_client
+        .query(&format!("DROP DATABASE IF EXISTS {db_name}"))
+        .execute()
+        .await
+        .unwrap();
+}
+
+fn get_default_download() -> Download {
+    Download {
+        id: Uuid::new_v4(),
+        recorded: Default::default(),
+        domain: Default::default(),
+        site_path: Default::default(),
+        user_id: Default::default(),
+        project_id: Default::default(),
+        version_id: Default::default(),
+        ip: get_default_ipv6(),
+        country: Default::default(),
+        user_agent: Default::default(),
+        headers: Default::default(),
+    }
+}
+
+fn get_default_playtime() -> Playtime {
+    Playtime {
+        id: Uuid::new_v4(),
+        recorded: Default::default(),
+        seconds: Default::default(),
+        user_id: Default::default(),
+        project_id: Default::default(),
+        version_id: Default::default(),
+        loader: Default::default(),
+        game_version: Default::default(),
+        parent: Default::default(),
+    }
+}
+
+fn get_default_views() -> PageView {
+    PageView {
+        id: Uuid::new_v4(),
+        recorded: Default::default(),
+        domain: Default::default(),
+        site_path: Default::default(),
+        user_id: Default::default(),
+        project_id: Default::default(),
+        ip: get_default_ipv6(),
+        country: Default::default(),
+        user_agent: Default::default(),
+        headers: Default::default(),
+    }
+}
+
+fn get_default_ipv6() -> Ipv6Addr {
+    Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)
+}

--- a/src/routes/analytics.rs
+++ b/src/routes/analytics.rs
@@ -150,7 +150,7 @@ pub async fn page_view_ingest(
         view.user_id = user.id.0;
     }
 
-    analytics_queue.add_view(view).await;
+    analytics_queue.add_view(view);
 
     Ok(HttpResponse::NoContent().body(""))
 }
@@ -202,19 +202,17 @@ pub async fn playtime_ingest(
         }
 
         if let Some(version) = versions.iter().find(|x| id == x.inner.id.into()) {
-            analytics_queue
-                .add_playtime(Playtime {
-                    id: Default::default(),
-                    recorded: Utc::now().timestamp_nanos() / 100_000,
-                    seconds: playtime.seconds as u64,
-                    user_id: user.id.0,
-                    project_id: version.inner.project_id.0 as u64,
-                    version_id: version.inner.id.0 as u64,
-                    loader: playtime.loader,
-                    game_version: playtime.game_version,
-                    parent: playtime.parent.map(|x| x.0).unwrap_or(0),
-                })
-                .await;
+            analytics_queue.add_playtime(Playtime {
+                id: Default::default(),
+                recorded: Utc::now().timestamp_nanos() / 100_000,
+                seconds: playtime.seconds as u64,
+                user_id: user.id.0,
+                project_id: version.inner.project_id.0 as u64,
+                version_id: version.inner.id.0 as u64,
+                loader: playtime.loader,
+                game_version: playtime.game_version,
+                parent: playtime.parent.map(|x| x.0).unwrap_or(0),
+            });
         }
     }
 

--- a/src/routes/v2/projects.rs
+++ b/src/routes/v2/projects.rs
@@ -2,6 +2,7 @@ use crate::auth::{filter_authorized_projects, get_user_from_headers, is_authoriz
 use crate::database;
 use crate::database::models::image_item;
 use crate::database::models::notification_item::NotificationBuilder;
+use crate::database::models::project_item::GalleryItem;
 use crate::database::models::thread_item::ThreadMessageBuilder;
 use crate::database::redis::RedisPool;
 use crate::file_hosting::FileHost;
@@ -2047,16 +2048,15 @@ pub async fn add_gallery_item(
             .await?;
         }
 
-        database::models::project_item::GalleryItem {
+        let gallery_item = vec![database::models::project_item::GalleryItem {
             image_url: file_url,
             featured: item.featured,
             title: item.title,
             description: item.description,
             created: Utc::now(),
             ordering: item.ordering.unwrap_or(0),
-        }
-        .insert(project_item.inner.id, &mut transaction)
-        .await?;
+        }];
+        GalleryItem::insert_many(gallery_item, project_item.inner.id, &mut transaction).await?;
 
         database::models::Project::clear_cache(
             project_item.inner.id,

--- a/src/routes/v2/version_creation.rs
+++ b/src/routes/v2/version_creation.rs
@@ -725,9 +725,7 @@ async fn upload_file_to_version_inner(
             "At least one file must be specified".to_string(),
         ));
     } else {
-        for file_builder in file_builders {
-            file_builder.insert(version_id, &mut *transaction).await?;
-        }
+        VersionFileBuilder::insert_many(file_builders, version_id, &mut *transaction).await?;
     }
 
     // Clear version cache

--- a/src/routes/v2/versions.rs
+++ b/src/routes/v2/versions.rs
@@ -3,7 +3,7 @@ use crate::auth::{
     filter_authorized_versions, get_user_from_headers, is_authorized, is_authorized_version,
 };
 use crate::database;
-use crate::database::models::version_item::DependencyBuilder;
+use crate::database::models::version_item::{DependencyBuilder, LoaderVersion, VersionVersion};
 use crate::database::models::{image_item, Organization};
 use crate::database::redis::RedisPool;
 use crate::models;
@@ -471,6 +471,7 @@ pub async fn version_edit(
                 .execute(&mut *transaction)
                 .await?;
 
+                let mut version_versions = Vec::new();
                 for game_version in game_versions {
                     let game_version_id = database::models::categories::GameVersion::get_id(
                         &game_version.0,
@@ -483,17 +484,9 @@ pub async fn version_edit(
                         )
                     })?;
 
-                    sqlx::query!(
-                        "
-                        INSERT INTO game_versions_versions (game_version_id, joining_version_id)
-                        VALUES ($1, $2)
-                        ",
-                        game_version_id as database::models::ids::GameVersionId,
-                        id as database::models::ids::VersionId,
-                    )
-                    .execute(&mut *transaction)
-                    .await?;
+                    version_versions.push(VersionVersion::new(game_version_id, id));
                 }
+                VersionVersion::insert_many(version_versions, &mut transaction).await?;
 
                 database::models::Project::update_game_versions(
                     version_item.inner.project_id,
@@ -512,6 +505,7 @@ pub async fn version_edit(
                 .execute(&mut *transaction)
                 .await?;
 
+                let mut loader_versions = Vec::new();
                 for loader in loaders {
                     let loader_id =
                         database::models::categories::Loader::get_id(&loader.0, &mut *transaction)
@@ -521,18 +515,9 @@ pub async fn version_edit(
                                     "No database entry for loader provided.".to_string(),
                                 )
                             })?;
-
-                    sqlx::query!(
-                        "
-                        INSERT INTO loaders_versions (loader_id, version_id)
-                        VALUES ($1, $2)
-                        ",
-                        loader_id as database::models::ids::LoaderId,
-                        id as database::models::ids::VersionId,
-                    )
-                    .execute(&mut *transaction)
-                    .await?;
+                    loader_versions.push(LoaderVersion::new(loader_id, id));
                 }
+                LoaderVersion::insert_many(loader_versions, &mut transaction).await?;
 
                 database::models::Project::update_loaders(
                     version_item.inner.project_id,

--- a/src/routes/v2/versions.rs
+++ b/src/routes/v2/versions.rs
@@ -3,6 +3,7 @@ use crate::auth::{
     filter_authorized_versions, get_user_from_headers, is_authorized, is_authorized_version,
 };
 use crate::database;
+use crate::database::models::version_item::DependencyBuilder;
 use crate::database::models::{image_item, Organization};
 use crate::database::redis::RedisPool;
 use crate::models;
@@ -450,11 +451,12 @@ pub async fn version_edit(
                             })
                             .collect::<Vec<database::models::version_item::DependencyBuilder>>();
 
-                        for dependency in builders {
-                            dependency
-                                .insert(version_item.inner.id, &mut transaction)
-                                .await?;
-                        }
+                        DependencyBuilder::insert_many(
+                            builders,
+                            version_item.inner.id,
+                            &mut transaction,
+                        )
+                        .await?;
                     }
                 }
             }


### PR DESCRIPTION
Convert all instances of inserts being done inside for loops that I could find (excluding doubly nested or other extra gnarly scenarios) into using batch inserts in the way [currently recommended by Sqlx](https://github.com/launchbadge/sqlx/blob/main/FAQ.md#how-can-i-bind-an-array-to-a-values-clause-how-can-i-do-bulk-inserts).

Most of the changes are pretty straightforward transformations where I replaced the for loop with an iterator statement that produces a vec per column. A few others were a bit more involved:
- Payouts couldn't be fully transformed because it's also doing updates inside its for loop. That part hasn't changed. Now we just push to some vecs as we iterate and do a bulk insert at the end
- Clickhouse was asking for some deduplication, so I refactored a bit to abstract commonalities between the different analytics. Because this was not the standard postgres refactor, and because it's relatively isolated, I wrote some tests around this.
- There was some very substantial duplication in `routes/v2/projects.rs` around category insertion, so I refactored commonalities there.

I also didn't touch notification inserts is pending in #723.

Not yet tested outside of existing route tests and the tests around clickhouse.