### PR TITLE
Remove scheduling webhook check

### DIFF
--- a/.idea/labrinth.iml
+++ b/.idea/labrinth.iml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="CPP_MODULE" version="4">
-  <component name="NewModuleRootManager">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/target/debug/build/ahash-7eac216debe9f38a/out" isTestSource="false" />
@@ -144,6 +145,7 @@
       <sourceFolder url="file://$MODULE_DIR$/target/debug/build/v_htmlescape-2dcc3d8195b1decd/out" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/target/debug/build/value-bag-61e3e358d251e1a5/out" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/target/debug/build/whoami-7d9ebcbbb2371986/out" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />

--- a/src/routes/v2/projects.rs
+++ b/src/routes/v2/projects.rs
@@ -1633,12 +1633,6 @@ pub async fn project_schedule(
             ));
         }
 
-        if project_item.inner.webhook_sent {
-            return Err(ApiError::InvalidInput(
-                "This project already has been published. It cannot be scheduled!".to_string(),
-            ));
-        }
-
         sqlx::query!(
             "
             UPDATE mods


### PR DESCRIPTION
Removed check that the project has been approved for project scheduling (not needed anymore)