### PR TITLE
Fixes filing search test

### DIFF
--- a/src/auth/checks.rs
+++ b/src/auth/checks.rs
@@ -186,7 +186,7 @@ impl ValidateAuthorized for models::OAuthClient {
                     "You don't have sufficient permissions to interact with this OAuth application"
                         .to_string(),
                 ))
-            }
+            };
         }
 
         Ok(())

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -1120,7 +1120,7 @@ async fn align_search_projects() {
 
         let projects = api
             .search_deserialized(
-                Some(&test_name),
+                Some(&format!("\"&{test_name}\"")),
                 Some(json!([["categories:fabric"]])),
                 USER_USER_PAT,
             )
@@ -1130,6 +1130,7 @@ async fn align_search_projects() {
             let project_model = api
                 .get_project(&project.id.to_string(), USER_USER_PAT)
                 .await;
+            assert_eq!(project_model.status(), 200);
             let mut project_model: Project = test::read_body_json(project_model).await;
 
             // Body/description is huge- don't store it in search, so it's OK if they differ here

--- a/tests/search.rs
+++ b/tests/search.rs
@@ -91,7 +91,11 @@ async fn search_projects() {
                 let test_name = test_name.clone();
                 async move {
                     let projects = api
-                        .search_deserialized(Some(&test_name), Some(facets.clone()), USER_USER_PAT)
+                        .search_deserialized(
+                            Some(&format!("\"&{test_name}\"")),
+                            Some(facets.clone()),
+                            USER_USER_PAT,
+                        )
                         .await;
                     let mut found_project_ids: Vec<u64> = projects
                         .hits

--- a/tests/v2/search.rs
+++ b/tests/v2/search.rs
@@ -292,7 +292,11 @@ async fn search_projects() {
                 let test_name = test_name.clone();
                 async move {
                     let projects = api
-                        .search_deserialized(Some(&test_name), Some(facets.clone()), USER_USER_PAT)
+                        .search_deserialized(
+                            Some(&format!("\"&{test_name}\"")),
+                            Some(facets.clone()),
+                            USER_USER_PAT,
+                        )
                         .await;
                     let mut found_project_ids: Vec<u64> = projects
                         .hits
@@ -309,7 +313,7 @@ async fn search_projects() {
         // A couple additional tests for the saerch type returned, making sure it is properly translated back
         let client_side_required = api
             .search_deserialized(
-                Some(&test_name),
+                Some(&format!("\"&{test_name}\"")),
                 Some(json!([["client_side:required"]])),
                 USER_USER_PAT,
             )
@@ -320,7 +324,7 @@ async fn search_projects() {
 
         let server_side_required = api
             .search_deserialized(
-                Some(&test_name),
+                Some(&format!("\"&{test_name}\"")),
                 Some(json!([["server_side:required"]])),
                 USER_USER_PAT,
             )
@@ -331,7 +335,7 @@ async fn search_projects() {
 
         let client_side_unsupported = api
             .search_deserialized(
-                Some(&test_name),
+                Some(&format!("\"&{test_name}\"")),
                 Some(json!([["client_side:unsupported"]])),
                 USER_USER_PAT,
             )
@@ -342,7 +346,7 @@ async fn search_projects() {
 
         let game_versions = api
             .search_deserialized(
-                Some(&test_name),
+                Some(&format!("\"&{test_name}\"")),
                 Some(json!([["versions:1.20.5"]])),
                 USER_USER_PAT,
             )


### PR DESCRIPTION
_ is considered a separator in meilisearch, which was causing the way we isolated searches amongst different tests to fail (as it searched for `search` `test` and `213123213` instead of `search_test_213123213`). This didn't matter until we had multiple tests involving searching.

I added quotes so it correctly isolates them