### PR TITLE
Allow uploading custom maven POMs as version files

### DIFF
--- a/src/routes/maven.rs
+++ b/src/routes/maven.rs
@@ -298,7 +298,11 @@ pub async fn version_file(
         return Err(ApiError::NotFound);
     }
 
-    if file == format!("{}-{}.pom", &project_id, &vnum) {
+    if let Some(selected_file) = find_file(&project_id, &vnum, &version, &file) {
+        return Ok(HttpResponse::TemporaryRedirect()
+            .append_header(("location", &*selected_file.url))
+            .body(""));
+    } else if file == format!("{}-{}.pom", &project_id, &vnum) {
         let respdata = MavenPom {
             schema_location:
                 "http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
@@ -314,10 +318,6 @@ pub async fn version_file(
         return Ok(HttpResponse::Ok()
             .content_type("text/xml")
             .body(yaserde::ser::to_string(&respdata).map_err(ApiError::Xml)?));
-    } else if let Some(selected_file) = find_file(&project_id, &vnum, &version, &file) {
-        return Ok(HttpResponse::TemporaryRedirect()
-            .append_header(("location", &*selected_file.url))
-            .body(""));
     }
 
     Err(ApiError::NotFound)

--- a/src/util/ext.rs
+++ b/src/util/ext.rs
@@ -25,6 +25,7 @@ pub fn project_file_type(ext: &str) -> Option<&str> {
         "jar" => Some("application/java-archive"),
         "zip" | "litemod" => Some("application/zip"),
         "mrpack" => Some("application/x-modrinth-modpack+zip"),
+        "pom" => Some("text/xml"),
         _ => None,
     }
 }

--- a/src/validate/mod.rs
+++ b/src/validate/mod.rs
@@ -86,7 +86,7 @@ pub trait Validator: Sync {
     ) -> Result<ValidationResult, ValidationError>;
 }
 
-static ALWAYS_ALLOWED_EXT: &[&str] = &["zip", "txt"];
+static ALWAYS_ALLOWED_EXT: &[&str] = &["zip", "txt", "pom"];
 
 static VALIDATORS: &[&dyn Validator] = &[
     &ModpackValidator,


### PR DESCRIPTION
This PR allows uploading Maven POMs to versions and makes Modrinth Maven proxy them to the user.

WIP, since it doesn't really verify that the POM has the correct artifactId/groupId/version right now