### PR TITLE
Changes 'assert_status' to a macro

### DIFF
--- a/src/routes/v2_reroute.rs
+++ b/src/routes/v2_reroute.rs
@@ -15,7 +15,7 @@ pub async fn extract_ok_json<T>(response: HttpResponse) -> Result<T, HttpRespons
 where
     T: serde::de::DeserializeOwned,
 {
-    // If the response is OK, parse the json and return it
+    // If the response is StatusCode::OK, parse the json and return it
     if response.status() == actix_web::http::StatusCode::OK {
         let failure_http_response = || {
             HttpResponse::InternalServerError().json(json!({

--- a/tests/common/api_v2/project.rs
+++ b/tests/common/api_v2/project.rs
@@ -1,12 +1,15 @@
 use std::collections::HashMap;
 
-use crate::common::{
-    api_common::{
-        models::{CommonItemType, CommonProject, CommonVersion},
-        request_data::{ImageData, ProjectCreationRequestData},
-        Api, ApiProject, AppendsOptionalPat,
+use crate::{
+    assert_status,
+    common::{
+        api_common::{
+            models::{CommonItemType, CommonProject, CommonVersion},
+            request_data::{ImageData, ProjectCreationRequestData},
+            Api, ApiProject, AppendsOptionalPat,
+        },
+        dummy_data::TestFile,
     },
-    dummy_data::TestFile,
 };
 use actix_http::StatusCode;
 use actix_web::{
@@ -21,7 +24,7 @@ use labrinth::{
 };
 use serde_json::json;
 
-use crate::common::{asserts::assert_status, database::MOD_USER_PAT};
+use crate::common::database::MOD_USER_PAT;
 
 use super::{
     request_data::{self, get_public_project_creation_data},
@@ -35,7 +38,7 @@ impl ApiV2 {
         pat: Option<&str>,
     ) -> LegacyProject {
         let resp = self.get_project(id_or_slug, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         test::read_body_json(resp).await
     }
 
@@ -45,7 +48,7 @@ impl ApiV2 {
         pat: Option<&str>,
     ) -> Vec<LegacyProject> {
         let resp = self.get_user_projects(user_id_or_username, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         test::read_body_json(resp).await
     }
 
@@ -72,7 +75,7 @@ impl ApiV2 {
             .append_pat(pat)
             .to_request();
         let resp = self.call(req).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         test::read_body_json(resp).await
     }
 }
@@ -91,7 +94,7 @@ impl ApiProject for ApiV2 {
         // Add a project.
         let slug = creation_data.slug.clone();
         let resp = self.create_project(creation_data, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
 
         // Approve as a moderator.
         let req = TestRequest::patch()
@@ -104,7 +107,7 @@ impl ApiProject for ApiV2 {
             ))
             .to_request();
         let resp = self.call(req).await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         let project = self.get_project_deserialized_common(&slug, pat).await;
 
@@ -163,7 +166,7 @@ impl ApiProject for ApiV2 {
         pat: Option<&str>,
     ) -> CommonProject {
         let resp = self.get_project(id_or_slug, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         // First, deserialize to the non-common format (to test the response is valid for this api version)
         let project: LegacyProject = test::read_body_json(resp).await;
         // Then, deserialize to the common format
@@ -213,7 +216,7 @@ impl ApiProject for ApiV2 {
         pat: Option<&str>,
     ) -> Vec<CommonProject> {
         let resp = self.get_user_projects(user_id_or_username, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         // First, deserialize to the non-common format (to test the response is valid for this api version)
         let projects: Vec<LegacyProject> = test::read_body_json(resp).await;
         // Then, deserialize to the common format

--- a/tests/common/api_v2/tags.rs
+++ b/tests/common/api_v2/tags.rs
@@ -8,13 +8,15 @@ use labrinth::routes::v2::tags::{
     CategoryData, DonationPlatformQueryData, GameVersionQueryData, LoaderData,
 };
 
-use crate::common::{
-    api_common::{
-        models::{CommonCategoryData, CommonLoaderData},
-        Api, ApiTags, AppendsOptionalPat,
+use crate::{
+    assert_status,
+    common::{
+        api_common::{
+            models::{CommonCategoryData, CommonLoaderData},
+            Api, ApiTags, AppendsOptionalPat,
+        },
+        database::ADMIN_USER_PAT,
     },
-    asserts::assert_status,
-    database::ADMIN_USER_PAT,
 };
 
 use super::ApiV2;
@@ -32,7 +34,7 @@ impl ApiV2 {
 
     pub async fn get_side_types_deserialized(&self) -> Vec<String> {
         let resp = self.get_side_types().await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         test::read_body_json(resp).await
     }
 
@@ -46,19 +48,19 @@ impl ApiV2 {
 
     pub async fn get_game_versions_deserialized(&self) -> Vec<GameVersionQueryData> {
         let resp = self.get_game_versions().await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         test::read_body_json(resp).await
     }
 
     pub async fn get_loaders_deserialized(&self) -> Vec<LoaderData> {
         let resp = self.get_loaders().await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         test::read_body_json(resp).await
     }
 
     pub async fn get_categories_deserialized(&self) -> Vec<CategoryData> {
         let resp = self.get_categories().await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         test::read_body_json(resp).await
     }
 
@@ -72,7 +74,7 @@ impl ApiV2 {
 
     pub async fn get_donation_platforms_deserialized(&self) -> Vec<DonationPlatformQueryData> {
         let resp = self.get_donation_platforms().await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         test::read_body_json(resp).await
     }
 }
@@ -89,7 +91,7 @@ impl ApiTags for ApiV2 {
 
     async fn get_loaders_deserialized_common(&self) -> Vec<CommonLoaderData> {
         let resp = self.get_loaders().await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         // First, deserialize to the non-common format (to test the response is valid for this api version)
         let v: Vec<LoaderData> = test::read_body_json(resp).await;
         // Then, deserialize to the common format
@@ -107,7 +109,7 @@ impl ApiTags for ApiV2 {
 
     async fn get_categories_deserialized_common(&self) -> Vec<CommonCategoryData> {
         let resp = self.get_categories().await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         // First, deserialize to the non-common format (to test the response is valid for this api version)
         let v: Vec<CategoryData> = test::read_body_json(resp).await;
         // Then, deserialize to the common format

--- a/tests/common/api_v2/team.rs
+++ b/tests/common/api_v2/team.rs
@@ -7,12 +7,12 @@ use labrinth::models::{
 };
 use serde_json::json;
 
-use crate::common::{
-    api_common::{
+use crate::{
+    assert_status,
+    common::api_common::{
         models::{CommonNotification, CommonTeamMember},
         Api, ApiTeams, AppendsOptionalPat,
     },
-    asserts::assert_status,
 };
 
 use super::ApiV2;
@@ -24,7 +24,7 @@ impl ApiV2 {
         pat: Option<&str>,
     ) -> Vec<LegacyTeamMember> {
         let resp = self.get_organization_members(id_or_title, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         test::read_body_json(resp).await
     }
 
@@ -34,7 +34,7 @@ impl ApiV2 {
         pat: Option<&str>,
     ) -> Vec<LegacyTeamMember> {
         let resp = self.get_team_members(team_id, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         test::read_body_json(resp).await
     }
 
@@ -44,7 +44,7 @@ impl ApiV2 {
         pat: Option<&str>,
     ) -> Vec<LegacyNotification> {
         let resp = self.get_user_notifications(user_id, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         test::read_body_json(resp).await
     }
 }
@@ -65,7 +65,7 @@ impl ApiTeams for ApiV2 {
         pat: Option<&str>,
     ) -> Vec<CommonTeamMember> {
         let resp = self.get_team_members(id_or_title, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         // TODO: Note, this does NOT deserialize to any other struct first, as currently TeamMember is the same in v2 and v3.
         // CommonTeamMember = TeamMember (v3)
         // This may yet change, so we should keep common struct.
@@ -102,7 +102,7 @@ impl ApiTeams for ApiV2 {
         pat: Option<&str>,
     ) -> Vec<CommonTeamMember> {
         let resp = self.get_project_members(id_or_title, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         // TODO: Note, this does NOT deserialize to any other struct first, as currently TeamMember is the same in v2 and v3.
         // CommonTeamMember = TeamMember (v3)
         // This may yet change, so we should keep common struct.
@@ -127,7 +127,7 @@ impl ApiTeams for ApiV2 {
         pat: Option<&str>,
     ) -> Vec<CommonTeamMember> {
         let resp = self.get_organization_members(id_or_title, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         // TODO: Note, this does NOT deserialize to any other struct first, as currently TeamMember is the same in v2 and v3.
         // CommonTeamMember = TeamMember (v3)
         // This may yet change, so we should keep common struct.
@@ -200,7 +200,7 @@ impl ApiTeams for ApiV2 {
         pat: Option<&str>,
     ) -> Vec<CommonNotification> {
         let resp = self.get_user_notifications(user_id, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         // First, deserialize to the non-common format (to test the response is valid for this api version)
         let v: Vec<LegacyNotification> = test::read_body_json(resp).await;
         // Then, deserialize to the common format

--- a/tests/common/api_v2/version.rs
+++ b/tests/common/api_v2/version.rs
@@ -4,10 +4,12 @@ use super::{
     request_data::{self, get_public_version_creation_data},
     ApiV2,
 };
-use crate::common::{
-    api_common::{models::CommonVersion, Api, ApiVersion, AppendsOptionalPat},
-    asserts::assert_status,
-    dummy_data::TestFile,
+use crate::{
+    assert_status,
+    common::{
+        api_common::{models::CommonVersion, Api, ApiVersion, AppendsOptionalPat},
+        dummy_data::TestFile,
+    },
 };
 use actix_http::StatusCode;
 use actix_web::{
@@ -33,7 +35,7 @@ pub fn url_encode_json_serialized_vec(elements: &[String]) -> String {
 impl ApiV2 {
     pub async fn get_version_deserialized(&self, id: &str, pat: Option<&str>) -> LegacyVersion {
         let resp = self.get_version(id, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         test::read_body_json(resp).await
     }
 
@@ -44,7 +46,7 @@ impl ApiV2 {
         pat: Option<&str>,
     ) -> LegacyVersion {
         let resp = self.get_version_from_hash(hash, algorithm, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         test::read_body_json(resp).await
     }
 
@@ -55,7 +57,7 @@ impl ApiV2 {
         pat: Option<&str>,
     ) -> HashMap<String, LegacyVersion> {
         let resp = self.get_versions_from_hashes(hashes, algorithm, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         test::read_body_json(resp).await
     }
 
@@ -83,7 +85,7 @@ impl ApiV2 {
         pat: Option<&str>,
     ) -> HashMap<String, LegacyVersion> {
         let resp = self.update_individual_files(algorithm, hashes, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         test::read_body_json(resp).await
     }
 }
@@ -135,7 +137,7 @@ impl ApiVersion for ApiV2 {
                 pat,
             )
             .await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         // First, deserialize to the non-common format (to test the response is valid for this api version)
         let v: LegacyVersion = test::read_body_json(resp).await;
         // Then, deserialize to the common format
@@ -153,7 +155,7 @@ impl ApiVersion for ApiV2 {
 
     async fn get_version_deserialized_common(&self, id: &str, pat: Option<&str>) -> CommonVersion {
         let resp = self.get_version(id, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         // First, deserialize to the non-common format (to test the response is valid for this api version)
         let v: LegacyVersion = test::read_body_json(resp).await;
         // Then, deserialize to the common format
@@ -212,7 +214,7 @@ impl ApiVersion for ApiV2 {
         pat: Option<&str>,
     ) -> CommonVersion {
         let resp = self.get_version_from_hash(hash, algorithm, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         // First, deserialize to the non-common format (to test the response is valid for this api version)
         let v: LegacyVersion = test::read_body_json(resp).await;
         // Then, deserialize to the common format
@@ -244,7 +246,7 @@ impl ApiVersion for ApiV2 {
         pat: Option<&str>,
     ) -> HashMap<String, CommonVersion> {
         let resp = self.get_versions_from_hashes(hashes, algorithm, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         // First, deserialize to the non-common format (to test the response is valid for this api version)
         let v: HashMap<String, LegacyVersion> = test::read_body_json(resp).await;
         // Then, deserialize to the common format
@@ -287,7 +289,7 @@ impl ApiVersion for ApiV2 {
         let resp = self
             .get_update_from_hash(hash, algorithm, loaders, game_versions, version_types, pat)
             .await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         // First, deserialize to the non-common format (to test the response is valid for this api version)
         let v: LegacyVersion = test::read_body_json(resp).await;
         // Then, deserialize to the common format
@@ -337,7 +339,7 @@ impl ApiVersion for ApiV2 {
                 pat,
             )
             .await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         // First, deserialize to the non-common format (to test the response is valid for this api version)
         let v: HashMap<String, LegacyVersion> = test::read_body_json(resp).await;
         // Then, deserialize to the common format
@@ -420,7 +422,7 @@ impl ApiVersion for ApiV2 {
                 pat,
             )
             .await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         // First, deserialize to the non-common format (to test the response is valid for this api version)
         let v: Vec<LegacyVersion> = test::read_body_json(resp).await;
         // Then, deserialize to the common format
@@ -461,7 +463,7 @@ impl ApiVersion for ApiV2 {
         pat: Option<&str>,
     ) -> Vec<CommonVersion> {
         let resp = self.get_versions(version_ids, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         // First, deserialize to the non-common format (to test the response is valid for this api version)
         let v: Vec<LegacyVersion> = test::read_body_json(resp).await;
         // Then, deserialize to the common format

--- a/tests/common/api_v3/collections.rs
+++ b/tests/common/api_v3/collections.rs
@@ -7,9 +7,9 @@ use bytes::Bytes;
 use labrinth::models::{collections::Collection, v3::projects::Project};
 use serde_json::json;
 
-use crate::common::{
-    api_common::{request_data::ImageData, Api, AppendsOptionalPat},
-    asserts::assert_status,
+use crate::{
+    assert_status,
+    common::api_common::{request_data::ImageData, Api, AppendsOptionalPat},
 };
 
 use super::ApiV3;
@@ -44,7 +44,7 @@ impl ApiV3 {
 
     pub async fn get_collection_deserialized(&self, id: &str, pat: Option<&str>) -> Collection {
         let resp = self.get_collection(id, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         test::read_body_json(resp).await
     }
 
@@ -74,7 +74,7 @@ impl ApiV3 {
         pat: Option<&str>,
     ) -> Vec<Project> {
         let resp = self.get_collection_projects(id, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         test::read_body_json(resp).await
     }
 
@@ -149,7 +149,7 @@ impl ApiV3 {
         pat: Option<&str>,
     ) -> Vec<Collection> {
         let resp = self.get_user_collections(user_id_or_username, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         // First, deserialize to the non-common format (to test the response is valid for this api version)
         let projects: Vec<Project> = test::read_body_json(resp).await;
         // Then, deserialize to the common format

--- a/tests/common/api_v3/oauth.rs
+++ b/tests/common/api_v3/oauth.rs
@@ -10,9 +10,9 @@ use labrinth::auth::oauth::{
 };
 use reqwest::header::{AUTHORIZATION, LOCATION};
 
-use crate::common::{
-    api_common::{Api, AppendsOptionalPat},
-    asserts::assert_status,
+use crate::{
+    assert_status,
+    common::api_common::{Api, AppendsOptionalPat},
 };
 
 use super::ApiV3;
@@ -117,20 +117,20 @@ pub fn generate_authorize_uri(
 }
 
 pub async fn get_authorize_accept_flow_id(response: ServiceResponse) -> String {
-    assert_status(&response, StatusCode::OK);
+    assert_status!(&response, StatusCode::OK);
     test::read_body_json::<OAuthClientAccessRequest, _>(response)
         .await
         .flow_id
 }
 
 pub async fn get_auth_code_from_redirect_params(response: &ServiceResponse) -> String {
-    assert_status(response, StatusCode::OK);
+    assert_status!(response, StatusCode::OK);
     let query_params = get_redirect_location_query_params(response);
     query_params.get("code").unwrap().to_string()
 }
 
 pub async fn get_access_token(response: ServiceResponse) -> String {
-    assert_status(&response, StatusCode::OK);
+    assert_status!(&response, StatusCode::OK);
     test::read_body_json::<TokenResponse, _>(response)
         .await
         .access_token

--- a/tests/common/api_v3/oauth_clients.rs
+++ b/tests/common/api_v3/oauth_clients.rs
@@ -12,9 +12,9 @@ use labrinth::{
 };
 use serde_json::json;
 
-use crate::common::{
-    api_common::{Api, AppendsOptionalPat},
-    asserts::assert_status,
+use crate::{
+    assert_status,
+    common::api_common::{Api, AppendsOptionalPat},
 };
 
 use super::ApiV3;
@@ -51,7 +51,7 @@ impl ApiV3 {
             .append_pat(pat)
             .to_request();
         let resp = self.call(req).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
 
         test::read_body_json(resp).await
     }
@@ -116,7 +116,7 @@ impl ApiV3 {
             .append_pat(pat)
             .to_request();
         let resp = self.call(req).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
 
         test::read_body_json(resp).await
     }

--- a/tests/common/api_v3/organization.rs
+++ b/tests/common/api_v3/organization.rs
@@ -7,9 +7,9 @@ use bytes::Bytes;
 use labrinth::models::{organizations::Organization, users::UserId, v3::projects::Project};
 use serde_json::json;
 
-use crate::common::{
-    api_common::{request_data::ImageData, Api, AppendsOptionalPat},
-    asserts::assert_status,
+use crate::{
+    assert_status,
+    common::api_common::{request_data::ImageData, Api, AppendsOptionalPat},
 };
 
 use super::ApiV3;
@@ -48,7 +48,7 @@ impl ApiV3 {
         pat: Option<&str>,
     ) -> Organization {
         let resp = self.get_organization(id_or_title, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         test::read_body_json(resp).await
     }
 
@@ -86,7 +86,7 @@ impl ApiV3 {
         pat: Option<&str>,
     ) -> Vec<Project> {
         let resp = self.get_organization_projects(id_or_title, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         test::read_body_json(resp).await
     }
 

--- a/tests/common/api_v3/project.rs
+++ b/tests/common/api_v3/project.rs
@@ -16,15 +16,17 @@ use labrinth::{
 use rust_decimal::Decimal;
 use serde_json::json;
 
-use crate::common::{
-    api_common::{
-        models::{CommonItemType, CommonProject, CommonVersion},
-        request_data::{ImageData, ProjectCreationRequestData},
-        Api, ApiProject, AppendsOptionalPat,
+use crate::{
+    assert_status,
+    common::{
+        api_common::{
+            models::{CommonItemType, CommonProject, CommonVersion},
+            request_data::{ImageData, ProjectCreationRequestData},
+            Api, ApiProject, AppendsOptionalPat,
+        },
+        database::MOD_USER_PAT,
+        dummy_data::TestFile,
     },
-    asserts::assert_status,
-    database::MOD_USER_PAT,
-    dummy_data::TestFile,
 };
 
 use super::{
@@ -46,7 +48,7 @@ impl ApiProject for ApiV3 {
         // Add a project.
         let slug = creation_data.slug.clone();
         let resp = self.create_project(creation_data, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
 
         // Approve as a moderator.
         let req = TestRequest::patch()
@@ -59,7 +61,7 @@ impl ApiProject for ApiV3 {
             ))
             .to_request();
         let resp = self.call(req).await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         let project = self.get_project(&slug, pat).await;
         let project = test::read_body_json(project).await;
@@ -119,7 +121,7 @@ impl ApiProject for ApiV3 {
         pat: Option<&str>,
     ) -> CommonProject {
         let resp = self.get_project(id_or_slug, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         // First, deserialize to the non-common format (to test the response is valid for this api version)
         let project: Project = test::read_body_json(resp).await;
         // Then, deserialize to the common format
@@ -169,7 +171,7 @@ impl ApiProject for ApiV3 {
         pat: Option<&str>,
     ) -> Vec<CommonProject> {
         let resp = self.get_user_projects(user_id_or_username, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         // First, deserialize to the non-common format (to test the response is valid for this api version)
         let projects: Vec<Project> = test::read_body_json(resp).await;
         // Then, deserialize to the common format
@@ -477,7 +479,7 @@ impl ApiProject for ApiV3 {
 impl ApiV3 {
     pub async fn get_project_deserialized(&self, id_or_slug: &str, pat: Option<&str>) -> Project {
         let resp = self.get_project(id_or_slug, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         test::read_body_json(resp).await
     }
 
@@ -500,7 +502,7 @@ impl ApiV3 {
         pat: Option<&str>,
     ) -> Organization {
         let resp = self.get_project_organization(id_or_slug, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         test::read_body_json(resp).await
     }
 
@@ -527,7 +529,7 @@ impl ApiV3 {
             .append_pat(pat)
             .to_request();
         let resp = self.call(req).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         test::read_body_json(resp).await
     }
 
@@ -594,7 +596,7 @@ impl ApiV3 {
                 pat,
             )
             .await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         test::read_body_json(resp).await
     }
 }

--- a/tests/common/api_v3/tags.rs
+++ b/tests/common/api_v3/tags.rs
@@ -9,13 +9,15 @@ use labrinth::{
     database::models::loader_fields::LoaderFieldEnumValue, routes::v3::tags::CategoryData,
 };
 
-use crate::common::{
-    api_common::{
-        models::{CommonCategoryData, CommonLoaderData},
-        Api, ApiTags, AppendsOptionalPat,
+use crate::{
+    assert_status,
+    common::{
+        api_common::{
+            models::{CommonCategoryData, CommonLoaderData},
+            Api, ApiTags, AppendsOptionalPat,
+        },
+        database::ADMIN_USER_PAT,
     },
-    asserts::assert_status,
-    database::ADMIN_USER_PAT,
 };
 
 use super::ApiV3;
@@ -32,7 +34,7 @@ impl ApiTags for ApiV3 {
 
     async fn get_loaders_deserialized_common(&self) -> Vec<CommonLoaderData> {
         let resp = self.get_loaders().await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         // First, deserialize to the non-common format (to test the response is valid for this api version)
         let v: Vec<LoaderData> = test::read_body_json(resp).await;
         // Then, deserialize to the common format
@@ -50,7 +52,7 @@ impl ApiTags for ApiV3 {
 
     async fn get_categories_deserialized_common(&self) -> Vec<CommonCategoryData> {
         let resp = self.get_categories().await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         // First, deserialize to the non-common format (to test the response is valid for this api version)
         let v: Vec<CategoryData> = test::read_body_json(resp).await;
         // Then, deserialize to the common format
@@ -62,7 +64,7 @@ impl ApiTags for ApiV3 {
 impl ApiV3 {
     pub async fn get_loaders_deserialized(&self) -> Vec<LoaderData> {
         let resp = self.get_loaders().await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         test::read_body_json(resp).await
     }
 
@@ -79,7 +81,7 @@ impl ApiV3 {
         loader_field: &str,
     ) -> Vec<LoaderFieldEnumValue> {
         let resp = self.get_loader_field_variants(loader_field).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         test::read_body_json(resp).await
     }
 
@@ -94,7 +96,7 @@ impl ApiV3 {
 
     pub async fn get_games_deserialized(&self) -> Vec<GameData> {
         let resp = self.get_games().await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         test::read_body_json(resp).await
     }
 }

--- a/tests/common/api_v3/team.rs
+++ b/tests/common/api_v3/team.rs
@@ -7,12 +7,12 @@ use labrinth::models::{
 };
 use serde_json::json;
 
-use crate::common::{
-    api_common::{
+use crate::{
+    assert_status,
+    common::api_common::{
         models::{CommonNotification, CommonTeamMember},
         Api, ApiTeams, AppendsOptionalPat,
     },
-    asserts::assert_status,
 };
 
 use super::ApiV3;
@@ -24,7 +24,7 @@ impl ApiV3 {
         pat: Option<&str>,
     ) -> Vec<TeamMember> {
         let resp = self.get_organization_members(id_or_title, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         test::read_body_json(resp).await
     }
 
@@ -34,7 +34,7 @@ impl ApiV3 {
         pat: Option<&str>,
     ) -> Vec<TeamMember> {
         let resp = self.get_team_members(team_id, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         test::read_body_json(resp).await
     }
 
@@ -44,7 +44,7 @@ impl ApiV3 {
         pat: Option<&str>,
     ) -> Vec<TeamMember> {
         let resp = self.get_project_members(project_id, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         test::read_body_json(resp).await
     }
 }
@@ -65,7 +65,7 @@ impl ApiTeams for ApiV3 {
         pat: Option<&str>,
     ) -> Vec<CommonTeamMember> {
         let resp = self.get_team_members(id_or_title, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         // First, deserialize to the non-common format (to test the response is valid for this api version)
         let v: Vec<TeamMember> = test::read_body_json(resp).await;
         // Then, deserialize to the common format
@@ -103,7 +103,7 @@ impl ApiTeams for ApiV3 {
         pat: Option<&str>,
     ) -> Vec<CommonTeamMember> {
         let resp = self.get_project_members(id_or_title, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         // First, deserialize to the non-common format (to test the response is valid for this api version)
         let v: Vec<TeamMember> = test::read_body_json(resp).await;
         // Then, deserialize to the common format
@@ -129,7 +129,7 @@ impl ApiTeams for ApiV3 {
         pat: Option<&str>,
     ) -> Vec<CommonTeamMember> {
         let resp = self.get_organization_members(id_or_title, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         // First, deserialize to the non-common format (to test the response is valid for this api version)
         let v: Vec<TeamMember> = test::read_body_json(resp).await;
         // Then, deserialize to the common format
@@ -203,7 +203,7 @@ impl ApiTeams for ApiV3 {
         pat: Option<&str>,
     ) -> Vec<CommonNotification> {
         let resp = self.get_user_notifications(user_id, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         // First, deserialize to the non-common format (to test the response is valid for this api version)
         let v: Vec<Notification> = test::read_body_json(resp).await;
         // Then, deserialize to the common format

--- a/tests/common/api_v3/version.rs
+++ b/tests/common/api_v3/version.rs
@@ -4,10 +4,12 @@ use super::{
     request_data::{self, get_public_version_creation_data},
     ApiV3,
 };
-use crate::common::{
-    api_common::{models::CommonVersion, Api, ApiVersion, AppendsOptionalPat},
-    asserts::assert_status,
-    dummy_data::TestFile,
+use crate::{
+    assert_status,
+    common::{
+        api_common::{models::CommonVersion, Api, ApiVersion, AppendsOptionalPat},
+        dummy_data::TestFile,
+    },
 };
 use actix_http::StatusCode;
 use actix_web::{
@@ -50,17 +52,17 @@ impl ApiV3 {
                 pat,
             )
             .await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         let value: serde_json::Value = test::read_body_json(resp).await;
         let version_id = value["id"].as_str().unwrap();
         let version = self.get_version(version_id, pat).await;
-        assert_status(&version, StatusCode::OK);
+        assert_status!(&version, StatusCode::OK);
         test::read_body_json(version).await
     }
 
     pub async fn get_version_deserialized(&self, id: &str, pat: Option<&str>) -> Version {
         let resp = self.get_version(id, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         test::read_body_json(resp).await
     }
 
@@ -88,7 +90,7 @@ impl ApiV3 {
         pat: Option<&str>,
     ) -> HashMap<String, Version> {
         let resp = self.update_individual_files(algorithm, hashes, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         test::read_body_json(resp).await
     }
 }
@@ -140,7 +142,7 @@ impl ApiVersion for ApiV3 {
                 pat,
             )
             .await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         // First, deserialize to the non-common format (to test the response is valid for this api version)
         let v: Version = test::read_body_json(resp).await;
         // Then, deserialize to the common format
@@ -158,7 +160,7 @@ impl ApiVersion for ApiV3 {
 
     async fn get_version_deserialized_common(&self, id: &str, pat: Option<&str>) -> CommonVersion {
         let resp = self.get_version(id, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         // First, deserialize to the non-common format (to test the response is valid for this api version)
         let v: Version = test::read_body_json(resp).await;
         // Then, deserialize to the common format
@@ -217,7 +219,7 @@ impl ApiVersion for ApiV3 {
         pat: Option<&str>,
     ) -> CommonVersion {
         let resp = self.get_version_from_hash(hash, algorithm, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         // First, deserialize to the non-common format (to test the response is valid for this api version)
         let v: Version = test::read_body_json(resp).await;
         // Then, deserialize to the common format
@@ -249,7 +251,7 @@ impl ApiVersion for ApiV3 {
         pat: Option<&str>,
     ) -> HashMap<String, CommonVersion> {
         let resp = self.get_versions_from_hashes(hashes, algorithm, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         // First, deserialize to the non-common format (to test the response is valid for this api version)
         let v: HashMap<String, Version> = test::read_body_json(resp).await;
         // Then, deserialize to the common format
@@ -301,7 +303,7 @@ impl ApiVersion for ApiV3 {
         let resp = self
             .get_update_from_hash(hash, algorithm, loaders, game_versions, version_types, pat)
             .await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         // First, deserialize to the non-common format (to test the response is valid for this api version)
         let v: Version = test::read_body_json(resp).await;
         // Then, deserialize to the common format
@@ -361,7 +363,7 @@ impl ApiVersion for ApiV3 {
                 pat,
             )
             .await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         // First, deserialize to the non-common format (to test the response is valid for this api version)
         let v: HashMap<String, Version> = test::read_body_json(resp).await;
         // Then, deserialize to the common format
@@ -444,7 +446,7 @@ impl ApiVersion for ApiV3 {
                 pat,
             )
             .await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         // First, deserialize to the non-common format (to test the response is valid for this api version)
         let v: Vec<Version> = test::read_body_json(resp).await;
         // Then, deserialize to the common format
@@ -486,7 +488,7 @@ impl ApiVersion for ApiV3 {
         pat: Option<&str>,
     ) -> Vec<CommonVersion> {
         let resp = self.get_versions(version_ids, pat).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         // First, deserialize to the non-common format (to test the response is valid for this api version)
         let v: Vec<Version> = test::read_body_json(resp).await;
         // Then, deserialize to the common format

--- a/tests/common/asserts.rs
+++ b/tests/common/asserts.rs
@@ -6,8 +6,28 @@ use labrinth::models::v3::projects::Version;
 
 use super::api_common::models::CommonVersion;
 
-pub fn assert_status(response: &actix_web::dev::ServiceResponse, status: actix_http::StatusCode) {
-    assert_eq!(response.status(), status, "{:#?}", response.response());
+#[macro_export]
+macro_rules! assert_status {
+    ($response:expr, $status:expr) => {
+        assert_eq!(
+            $response.status(),
+            $status,
+            "{:#?}",
+            $response.response().body()
+        );
+    };
+}
+
+#[macro_export]
+macro_rules! assert_any_status_except {
+    ($response:expr, $status:expr) => {
+        assert_ne!(
+            $response.status(),
+            $status,
+            "{:#?}",
+            $response.response().body()
+        );
+    };
 }
 
 pub fn assert_version_ids(versions: &[Version], expected_ids: Vec<String>) {
@@ -24,11 +44,4 @@ pub fn assert_common_version_ids(versions: &[CommonVersion], expected_ids: Vec<S
         .map(|v| get_json_val_str(v.id))
         .collect_vec();
     assert_eq!(version_ids, expected_ids);
-}
-
-pub fn assert_any_status_except(
-    response: &actix_web::dev::ServiceResponse,
-    status: actix_http::StatusCode,
-) {
-    assert_ne!(response.status(), status, "{:#?}", response.response());
 }

--- a/tests/common/dummy_data.rs
+++ b/tests/common/dummy_data.rs
@@ -13,7 +13,10 @@ use serde_json::json;
 use sqlx::Executor;
 use zip::{write::FileOptions, CompressionMethod, ZipWriter};
 
-use crate::common::{api_common::Api, database::USER_USER_PAT};
+use crate::{
+    assert_status,
+    common::{api_common::Api, database::USER_USER_PAT},
+};
 use labrinth::util::actix::{AppendsMultipart, MultipartSegment, MultipartSegmentData};
 
 use super::{
@@ -22,7 +25,7 @@ use super::{
     database::TemporaryDatabase,
 };
 
-use super::{asserts::assert_status, database::USER_USER_ID, get_json_val_str};
+use super::{database::USER_USER_ID, get_json_val_str};
 
 pub const DUMMY_DATA_UPDATE: i64 = 6;
 
@@ -390,7 +393,7 @@ pub async fn add_project_beta(api: &ApiV3) -> (Project, Version) {
         .set_multipart(vec![json_segment.clone(), file_segment.clone()])
         .to_request();
     let resp = api.call(req).await;
-    assert_status(&resp, StatusCode::OK);
+    assert_status!(&resp, StatusCode::OK);
 
     get_project_beta(api).await
 }
@@ -408,7 +411,7 @@ pub async fn add_organization_zeta(api: &ApiV3) -> Organization {
         .to_request();
     let resp = api.call(req).await;
 
-    assert_status(&resp, StatusCode::OK);
+    assert_status!(&resp, StatusCode::OK);
 
     get_organization_zeta(api).await
 }
@@ -441,7 +444,7 @@ pub async fn get_project_beta(api: &ApiV3) -> (Project, Version) {
         .append_pat(USER_USER_PAT)
         .to_request();
     let resp = api.call(req).await;
-    assert_status(&resp, StatusCode::OK);
+    assert_status!(&resp, StatusCode::OK);
     let project: serde_json::Value = test::read_body_json(resp).await;
     let project: Project = serde_json::from_value(project).unwrap();
 
@@ -451,7 +454,7 @@ pub async fn get_project_beta(api: &ApiV3) -> (Project, Version) {
         .append_pat(USER_USER_PAT)
         .to_request();
     let resp = api.call(req).await;
-    assert_status(&resp, StatusCode::OK);
+    assert_status!(&resp, StatusCode::OK);
     let versions: Vec<Version> = test::read_body_json(resp).await;
     let version = versions.into_iter().next().unwrap();
 

--- a/tests/common/environment.rs
+++ b/tests/common/environment.rs
@@ -4,11 +4,10 @@ use super::{
     api_common::{generic::GenericApi, Api, ApiBuildable},
     api_v2::ApiV2,
     api_v3::ApiV3,
-    asserts::assert_status,
     database::{TemporaryDatabase, FRIEND_USER_ID, USER_USER_PAT},
     dummy_data,
 };
-use crate::common::setup;
+use crate::{assert_status, common::setup};
 use actix_http::StatusCode;
 use actix_web::dev::ServiceResponse;
 use futures::Future;
@@ -112,7 +111,7 @@ impl<A: Api> TestEnvironment<A> {
                 USER_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
     }
 
     // Setup data, assert that a user can read notifications
@@ -123,7 +122,7 @@ impl<A: Api> TestEnvironment<A> {
         status_code: StatusCode,
     ) {
         let resp = self.api.get_user_notifications(user_id, pat).await;
-        assert_status(&resp, status_code);
+        assert_status!(&resp, status_code);
     }
 
     // Setup data, assert that a user can read projects notifications
@@ -134,7 +133,7 @@ impl<A: Api> TestEnvironment<A> {
         status_code: StatusCode,
     ) {
         let resp = self.api.get_user_projects(user_id, pat).await;
-        assert_status(&resp, status_code);
+        assert_status!(&resp, status_code);
     }
 }
 

--- a/tests/common/search.rs
+++ b/tests/common/search.rs
@@ -5,13 +5,16 @@ use std::{collections::HashMap, sync::Arc};
 use actix_http::StatusCode;
 use serde_json::json;
 
-use crate::common::{
-    api_common::{Api, ApiProject, ApiVersion},
-    database::{FRIEND_USER_PAT, MOD_USER_PAT, USER_USER_PAT},
-    dummy_data::{TestFile, DUMMY_CATEGORIES},
+use crate::{
+    assert_status,
+    common::{
+        api_common::{Api, ApiProject, ApiVersion},
+        database::{FRIEND_USER_PAT, MOD_USER_PAT, USER_USER_PAT},
+        dummy_data::{TestFile, DUMMY_CATEGORIES},
+    },
 };
 
-use super::{api_v3::ApiV3, asserts::assert_status, environment::TestEnvironment};
+use super::{api_v3::ApiV3, environment::TestEnvironment};
 
 pub async fn setup_search_projects(test_env: &TestEnvironment<ApiV3>) -> Arc<HashMap<u64, u64>> {
     // Test setup and dummy data
@@ -48,7 +51,7 @@ pub async fn setup_search_projects(test_env: &TestEnvironment<ApiV3>) -> Arc<Has
                         MOD_USER_PAT,
                     )
                     .await;
-                assert_status(&resp, StatusCode::NO_CONTENT);
+                assert_status!(&resp, StatusCode::NO_CONTENT);
                 (project.id.0, id)
             }
         };
@@ -210,7 +213,7 @@ pub async fn setup_search_projects(test_env: &TestEnvironment<ApiV3>) -> Arc<Has
 
     // Forcibly reset the search index
     let resp = api.reset_search_index().await;
-    assert_status(&resp, StatusCode::NO_CONTENT);
+    assert_status!(&resp, StatusCode::NO_CONTENT);
 
     id_conversion
 }

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -7,8 +7,6 @@ use common::api_v3::ApiV3;
 use common::database::USER_USER_PAT;
 use common::environment::{with_test_environment, TestEnvironment};
 
-use crate::common::asserts::assert_status;
-
 mod common;
 
 #[actix_rt::test]
@@ -17,7 +15,7 @@ pub async fn error_404_body() {
         // 3 errors should have 404 as non-blank body, for missing resources
         let api = &test_env.api;
         let resp = api.get_project("does-not-exist", USER_USER_PAT).await;
-        assert_status(&resp, StatusCode::NOT_FOUND);
+        assert_status!(&resp, StatusCode::NOT_FOUND);
         let body = test::read_body(resp).await;
         let empty_bytes = Bytes::from_static(b"");
         assert_ne!(body, empty_bytes);

--- a/tests/loader_fields.rs
+++ b/tests/loader_fields.rs
@@ -6,7 +6,6 @@ use common::environment::{with_test_environment, TestEnvironment};
 use serde_json::json;
 
 use crate::common::api_common::ApiVersion;
-use crate::common::asserts::assert_status;
 use crate::common::database::*;
 
 use crate::common::dummy_data::{DummyProjectAlpha, DummyProjectBeta, TestFile};
@@ -51,7 +50,7 @@ async fn creating_loader_fields() {
                 USER_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::BAD_REQUEST);
+        assert_status!(&resp, StatusCode::BAD_REQUEST);
         // - Patch
         let resp = api
             .edit_version(
@@ -62,7 +61,7 @@ async fn creating_loader_fields() {
                 USER_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::BAD_REQUEST);
+        assert_status!(&resp, StatusCode::BAD_REQUEST);
 
         // Cannot create a version with a loader field that isnt used by the loader
         // TODO: - Create project
@@ -84,7 +83,7 @@ async fn creating_loader_fields() {
                 USER_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::BAD_REQUEST);
+        assert_status!(&resp, StatusCode::BAD_REQUEST);
         // - Patch
         let resp = api
             .edit_version(
@@ -95,7 +94,7 @@ async fn creating_loader_fields() {
                 USER_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::BAD_REQUEST);
+        assert_status!(&resp, StatusCode::BAD_REQUEST);
 
         // Cannot create a version without an applicable loader field that is not optional
         // TODO: - Create project
@@ -117,7 +116,7 @@ async fn creating_loader_fields() {
             )
             .await;
 
-        assert_status(&resp, StatusCode::BAD_REQUEST);
+        assert_status!(&resp, StatusCode::BAD_REQUEST);
 
         // Cannot create a version without a loader field array that has a minimum of 1
         // TODO: - Create project
@@ -138,7 +137,7 @@ async fn creating_loader_fields() {
                 USER_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::BAD_REQUEST);
+        assert_status!(&resp, StatusCode::BAD_REQUEST);
 
         // TODO: Create a test for too many elements in the array when we have a LF that has a max (past max)
         // Cannot create a version with a loader field array that has fewer than the minimum elements
@@ -161,7 +160,7 @@ async fn creating_loader_fields() {
                 USER_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::BAD_REQUEST);
+        assert_status!(&resp, StatusCode::BAD_REQUEST);
 
         // - Patch
         let resp = api
@@ -173,7 +172,7 @@ async fn creating_loader_fields() {
                 USER_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::BAD_REQUEST);
+        assert_status!(&resp, StatusCode::BAD_REQUEST);
 
         // Cannot create an invalid data type for the loader field type (including bad variant for the type)
         for bad_type_game_versions in [
@@ -201,7 +200,7 @@ async fn creating_loader_fields() {
                     USER_USER_PAT,
                 )
                 .await;
-            assert_status(&resp, StatusCode::BAD_REQUEST);
+            assert_status!(&resp, StatusCode::BAD_REQUEST);
 
             // - Patch
             let resp = api
@@ -213,7 +212,7 @@ async fn creating_loader_fields() {
                     USER_USER_PAT,
                 )
                 .await;
-            assert_status(&resp, StatusCode::BAD_REQUEST);
+            assert_status!(&resp, StatusCode::BAD_REQUEST);
         }
 
         // Can create with optional loader fields (other tests have checked if we can create without them)
@@ -247,7 +246,7 @@ async fn creating_loader_fields() {
                 USER_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
         let v = api
             .get_version_deserialized(alpha_version_id, USER_USER_PAT)
             .await;
@@ -298,7 +297,7 @@ async fn creating_loader_fields() {
                 USER_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
         let v = api
             .get_version_deserialized(alpha_version_id, USER_USER_PAT)
             .await;

--- a/tests/oauth_clients.rs
+++ b/tests/oauth_clients.rs
@@ -15,7 +15,7 @@ use labrinth::{
     routes::v3::oauth_clients::OAuthClientEdit,
 };
 
-use common::{asserts::assert_status, database::USER_USER_ID_PARSED};
+use common::database::USER_USER_ID_PARSED;
 
 mod common;
 
@@ -36,7 +36,7 @@ async fn can_create_edit_get_oauth_client() {
                 FRIEND_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         let creation_result: OAuthClientCreationResult = test::read_body_json(resp).await;
         let client_id = get_json_val_str(creation_result.client.id);
 
@@ -59,7 +59,7 @@ async fn can_create_edit_get_oauth_client() {
             .api
             .edit_oauth_client(&client_id, edit, FRIEND_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
 
         let clients = env
             .api
@@ -90,7 +90,7 @@ async fn create_oauth_client_with_restricted_scopes_fails() {
             )
             .await;
 
-        assert_status(&resp, StatusCode::BAD_REQUEST);
+        assert_status!(&resp, StatusCode::BAD_REQUEST);
     })
     .await;
 }
@@ -105,7 +105,7 @@ async fn get_oauth_client_for_client_creator_succeeds() {
             .get_oauth_client(client_id.clone(), USER_USER_PAT)
             .await;
 
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         let client: OAuthClient = test::read_body_json(resp).await;
         assert_eq!(get_json_val_str(client.id), client_id);
     })
@@ -122,7 +122,7 @@ async fn get_oauth_client_for_unrelated_user_fails() {
             .get_oauth_client(client_id.clone(), FRIEND_USER_PAT)
             .await;
 
-        assert_status(&resp, StatusCode::UNAUTHORIZED);
+        assert_status!(&resp, StatusCode::UNAUTHORIZED);
     })
     .await;
 }
@@ -132,7 +132,7 @@ async fn can_delete_oauth_client() {
     with_test_environment(None, |env: TestEnvironment<ApiV3>| async move {
         let client_id = env.dummy.oauth_client_alpha.client_id.clone();
         let resp = env.api.delete_oauth_client(&client_id, USER_USER_PAT).await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         let clients = env
             .api

--- a/tests/organizations.rs
+++ b/tests/organizations.rs
@@ -1,6 +1,5 @@
 use crate::common::{
     api_common::{ApiProject, ApiTeams},
-    asserts::assert_status,
     database::{
         generate_random_name, ADMIN_USER_PAT, ENEMY_USER_ID_PARSED, ENEMY_USER_PAT,
         FRIEND_USER_ID_PARSED, MOD_USER_ID, MOD_USER_PAT, USER_USER_ID, USER_USER_ID_PARSED,
@@ -35,7 +34,7 @@ async fn create_organization() {
             let resp = api
                 .create_organization(title, "theta", "theta_description", USER_USER_PAT)
                 .await;
-            assert_status(&resp, StatusCode::BAD_REQUEST);
+            assert_status!(&resp, StatusCode::BAD_REQUEST);
         }
 
         // Failed creations slug:
@@ -52,7 +51,7 @@ async fn create_organization() {
             let resp = api
                 .create_organization("Theta Org", slug, "theta_description", USER_USER_PAT)
                 .await;
-            assert_status(&resp, StatusCode::BAD_REQUEST);
+            assert_status!(&resp, StatusCode::BAD_REQUEST);
         }
 
         // Failed creations description:
@@ -62,7 +61,7 @@ async fn create_organization() {
             let resp = api
                 .create_organization("Theta Org", "theta", description, USER_USER_PAT)
                 .await;
-            assert_status(&resp, StatusCode::BAD_REQUEST);
+            assert_status!(&resp, StatusCode::BAD_REQUEST);
         }
 
         // Create 'theta' organization
@@ -74,7 +73,7 @@ async fn create_organization() {
                 USER_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
 
         // Get organization using slug
         let theta = api
@@ -83,7 +82,7 @@ async fn create_organization() {
         assert_eq!(theta.name, "Theta Org");
         assert_eq!(theta.slug, "theta");
         assert_eq!(theta.description, "not url safe%&^!#$##!@#$%^&");
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
 
         // Get created team
         let members = api
@@ -113,7 +112,7 @@ async fn get_project_organization() {
         let resp = api
             .organization_add_project(zeta_organization_id, alpha_project_id, USER_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
 
         // Get project organization
         let zeta = api
@@ -135,7 +134,7 @@ async fn patch_organization() {
         let resp = api
             .create_organization("Theta Org", "theta", "theta_description", USER_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
 
         // Failed patch to theta title:
         // - too short title
@@ -150,7 +149,7 @@ async fn patch_organization() {
                     USER_USER_PAT,
                 )
                 .await;
-            assert_status(&resp, StatusCode::BAD_REQUEST);
+            assert_status!(&resp, StatusCode::BAD_REQUEST);
         }
 
         // Failed patch to zeta slug:
@@ -174,7 +173,7 @@ async fn patch_organization() {
                     USER_USER_PAT,
                 )
                 .await;
-            assert_status(&resp, StatusCode::BAD_REQUEST);
+            assert_status!(&resp, StatusCode::BAD_REQUEST);
         }
 
         // Failed patch to zeta description:
@@ -190,7 +189,7 @@ async fn patch_organization() {
                     USER_USER_PAT,
                 )
                 .await;
-            assert_status(&resp, StatusCode::BAD_REQUEST);
+            assert_status!(&resp, StatusCode::BAD_REQUEST);
         }
 
         // Successful patch to many fields
@@ -205,7 +204,7 @@ async fn patch_organization() {
                 USER_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // Get project using new slug
         let new_title = api
@@ -241,7 +240,7 @@ async fn add_remove_icon() {
                 USER_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // Get project
         let zeta_org = api
@@ -254,7 +253,7 @@ async fn add_remove_icon() {
         let resp = api
             .edit_organization_icon(zeta_organization_id, None, USER_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // Get project
         let zeta_org = api
@@ -275,13 +274,13 @@ async fn delete_org() {
         let resp = api
             .delete_organization(zeta_organization_id, USER_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // Get organization, which should no longer exist
         let resp = api
             .get_organization(zeta_organization_id, USER_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::NOT_FOUND);
+        assert_status!(&resp, StatusCode::NOT_FOUND);
     })
     .await;
 }
@@ -300,7 +299,7 @@ async fn add_remove_organization_projects() {
                 .api
                 .organization_add_project(zeta_organization_id, alpha, USER_USER_PAT)
                 .await;
-            assert_status(&resp, StatusCode::OK);
+            assert_status!(&resp, StatusCode::OK);
 
             // Get organization projects
             let projects = test_env
@@ -320,7 +319,7 @@ async fn add_remove_organization_projects() {
                     USER_USER_PAT,
                 )
                 .await;
-            assert_status(&resp, StatusCode::OK);
+            assert_status!(&resp, StatusCode::OK);
 
             // Get organization projects
             let projects = test_env
@@ -374,11 +373,11 @@ async fn add_remove_organization_project_ownership_to_user() {
                     USER_USER_PAT,
                 )
                 .await;
-            assert_status(&resp, StatusCode::NO_CONTENT);
+            assert_status!(&resp, StatusCode::NO_CONTENT);
 
             // Accept invites
             let resp = test_env.api.join_team(team, FRIEND_USER_PAT).await;
-            assert_status(&resp, StatusCode::NO_CONTENT);
+            assert_status!(&resp, StatusCode::NO_CONTENT);
         }
 
         // For each team, confirm there are two members, but only one owner of the project, and it is USER_USER_ID
@@ -398,7 +397,7 @@ async fn add_remove_organization_project_ownership_to_user() {
             .api
             .transfer_team_ownership(beta_team_id, FRIEND_USER_ID, USER_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // Confirm there are still two users, but now FRIEND_USER_ID is the owner
         let members = test_env
@@ -419,7 +418,7 @@ async fn add_remove_organization_project_ownership_to_user() {
                 .api
                 .organization_add_project(zeta_organization_id, project_id, pat)
                 .await;
-            assert_status(&resp, StatusCode::OK);
+            assert_status!(&resp, StatusCode::OK);
 
             // Get and confirm it has been added
             let project = test_env.api.get_project_deserialized(project_id, pat).await;
@@ -452,7 +451,7 @@ async fn add_remove_organization_project_ownership_to_user() {
             .api
             .transfer_team_ownership(zeta_team_id, FRIEND_USER_ID, USER_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // Confirm there are no members of the alpha project OR the beta project
         // - Friend was removed as a member of these projects when ownership was transferred to them
@@ -469,14 +468,14 @@ async fn add_remove_organization_project_ownership_to_user() {
             .api
             .add_user_to_team(alpha_team_id, FRIEND_USER_ID, None, None, USER_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::BAD_REQUEST);
+        assert_status!(&resp, StatusCode::BAD_REQUEST);
 
         // As friend, can add user to alpha project, as they are not the org owner
         let resp = test_env
             .api
             .add_user_to_team(alpha_team_id, USER_USER_ID, None, None, FRIEND_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // At this point, friend owns the org
         // Alpha member has user as a member, but not as an owner
@@ -493,7 +492,7 @@ async fn add_remove_organization_project_ownership_to_user() {
                 USER_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::BAD_REQUEST);
+        assert_status!(&resp, StatusCode::BAD_REQUEST);
 
         // Set user's permissions within the project that it is a member of to none (for a later test)
         let resp = test_env
@@ -507,7 +506,7 @@ async fn add_remove_organization_project_ownership_to_user() {
                 FRIEND_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // Remove project from organization with a user that is an organization member, and a project member
         // This should succeed
@@ -520,7 +519,7 @@ async fn add_remove_organization_project_ownership_to_user() {
                 USER_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
 
         // Remove project from organization with a user that is an organization member, but not a project member
         // This should succeed
@@ -533,7 +532,7 @@ async fn add_remove_organization_project_ownership_to_user() {
                 USER_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
 
         // For each of alpha and beta, confirm:
         // - There is one member of each project, the owner, USER_USER_ID
@@ -595,11 +594,11 @@ async fn delete_organization_means_all_projects_to_org_owner() {
             .api
             .add_user_to_team(zeta_team_id, FRIEND_USER_ID, None, None, USER_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // Accept invite
         let resp = test_env.api.join_team(zeta_team_id, FRIEND_USER_PAT).await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // Confirm there is only one owner of the project, and it is USER_USER_ID
         let members = test_env
@@ -615,7 +614,7 @@ async fn delete_organization_means_all_projects_to_org_owner() {
             .api
             .organization_add_project(zeta_organization_id, alpha_project_id, USER_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
 
         // Add beta to zeta organization
         test_env
@@ -628,13 +627,13 @@ async fn delete_organization_means_all_projects_to_org_owner() {
             .api
             .add_user_to_team(beta_team_id, FRIEND_USER_ID, None, None, USER_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // Try to accept invite
         // This returns a failure, because since beta and FRIEND are in the organizations,
         // they can be added to the project without an invite
         let resp = test_env.api.join_team(beta_team_id, FRIEND_USER_PAT).await;
-        assert_status(&resp, StatusCode::BAD_REQUEST);
+        assert_status!(&resp, StatusCode::BAD_REQUEST);
 
         // Confirm there is NO owner of the project, as it is owned by the organization
         let members = test_env
@@ -649,7 +648,7 @@ async fn delete_organization_means_all_projects_to_org_owner() {
             .api
             .transfer_team_ownership(zeta_team_id, FRIEND_USER_ID, USER_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // Confirm there is NO owner of the project, as it is owned by the organization
         let members = test_env
@@ -664,7 +663,7 @@ async fn delete_organization_means_all_projects_to_org_owner() {
             .api
             .delete_organization(zeta_organization_id, FRIEND_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // Confirm there is only one owner of the alpha project, and it is now FRIEND_USER_ID
         let members = test_env
@@ -850,9 +849,9 @@ async fn permissions_manage_invites() {
         let resp = api
             .add_user_to_team(zeta_team_id, MOD_USER_ID, None, None, ADMIN_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
         let resp = api.join_team(zeta_team_id, MOD_USER_PAT).await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // remove existing member (requires remove_member)
         let remove_member = OrganizationPermissions::REMOVE_MEMBER;
@@ -888,13 +887,13 @@ async fn permissions_add_remove_project() {
         let resp = api
             .add_user_to_team(alpha_team_id, FRIEND_USER_ID, None, None, USER_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
         let resp = api.join_team(alpha_team_id, FRIEND_USER_PAT).await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
         let resp = api
             .transfer_team_ownership(alpha_team_id, FRIEND_USER_ID, USER_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // Now, FRIEND_USER_ID owns the alpha project
         // Add alpha project to zeta organization

--- a/tests/pats.rs
+++ b/tests/pats.rs
@@ -6,7 +6,7 @@ use common::{database::*, environment::with_test_environment_all};
 use labrinth::models::pats::Scopes;
 use serde_json::json;
 
-use crate::common::{api_common::AppendsOptionalPat, asserts::assert_status};
+use crate::common::api_common::AppendsOptionalPat;
 
 mod common;
 
@@ -31,7 +31,7 @@ pub async fn pat_full_test() {
             }))
             .to_request();
         let resp = test_env.call(req).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         let success: serde_json::Value = test::read_body_json(resp).await;
         let id = success["id"].as_str().unwrap();
 
@@ -49,7 +49,7 @@ pub async fn pat_full_test() {
             .uri("/_internal/pat")
             .to_request();
         let resp = test_env.call(req).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         let success: serde_json::Value = test::read_body_json(resp).await;
 
         // Ensure access token is NOT returned for any PATs
@@ -88,7 +88,7 @@ pub async fn pat_full_test() {
             }))
             .to_request();
         let resp = test_env.call(req).await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
         assert_eq!(mock_pat_test(access_token).await, 401); // No longer works
 
         // Change scopes back, and set expiry to the past, and test again
@@ -101,7 +101,7 @@ pub async fn pat_full_test() {
             }))
             .to_request();
         let resp = test_env.call(req).await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // Wait 1 second before testing again for expiry
         tokio::time::sleep(Duration::seconds(1).to_std().unwrap()).await;
@@ -116,7 +116,7 @@ pub async fn pat_full_test() {
             }))
             .to_request();
         let resp = test_env.call(req).await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
         assert_eq!(mock_pat_test(access_token).await, 200); // Works again
 
         // Patching to a bad expiry should fail
@@ -128,7 +128,7 @@ pub async fn pat_full_test() {
             }))
             .to_request();
         let resp = test_env.call(req).await;
-        assert_status(&resp, StatusCode::BAD_REQUEST);
+        assert_status!(&resp, StatusCode::BAD_REQUEST);
 
         // Similar to above with PAT creation, patching to a bad scope should fail
         for i in 0..64 {
@@ -157,7 +157,7 @@ pub async fn pat_full_test() {
             .uri(&format!("/_internal/pat/{}", id))
             .to_request();
         let resp = test_env.call(req).await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
     })
     .await;
 }
@@ -176,7 +176,7 @@ pub async fn bad_pats() {
             }))
             .to_request();
         let resp = test_env.call(req).await;
-        assert_status(&resp, StatusCode::BAD_REQUEST);
+        assert_status!(&resp, StatusCode::BAD_REQUEST);
 
         // Name too short or too long should fail
         for name in ["n", "this_name_is_too_long".repeat(16).as_str()] {
@@ -190,7 +190,7 @@ pub async fn bad_pats() {
                 }))
                 .to_request();
             let resp = test_env.call(req).await;
-            assert_status(&resp, StatusCode::BAD_REQUEST);
+            assert_status!(&resp, StatusCode::BAD_REQUEST);
         }
 
         // Creating a PAT with an expiry in the past should fail
@@ -204,7 +204,7 @@ pub async fn bad_pats() {
             }))
             .to_request();
         let resp = test_env.call(req).await;
-        assert_status(&resp, StatusCode::BAD_REQUEST);
+        assert_status!(&resp, StatusCode::BAD_REQUEST);
 
         // Make a PAT with each scope, with the result varying by whether that scope is restricted
         for i in 0..64 {
@@ -239,7 +239,7 @@ pub async fn bad_pats() {
             }))
             .to_request();
         let resp = test_env.call(req).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         let success: serde_json::Value = test::read_body_json(resp).await;
         let id = success["id"].as_str().unwrap();
 
@@ -253,7 +253,7 @@ pub async fn bad_pats() {
                 }))
                 .to_request();
             let resp = test_env.call(req).await;
-            assert_status(&resp, StatusCode::BAD_REQUEST);
+            assert_status!(&resp, StatusCode::BAD_REQUEST);
         }
 
         // Patching to a bad expiry should fail
@@ -265,7 +265,7 @@ pub async fn bad_pats() {
             }))
             .to_request();
         let resp = test_env.call(req).await;
-        assert_status(&resp, StatusCode::BAD_REQUEST);
+        assert_status!(&resp, StatusCode::BAD_REQUEST);
 
         // Similar to above with PAT creation, patching to a bad scope should fail
         for i in 0..64 {

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -3,7 +3,6 @@ use std::collections::HashMap;
 use actix_http::StatusCode;
 use actix_web::test;
 use common::api_v3::ApiV3;
-use common::asserts::assert_status;
 use common::database::*;
 use common::dummy_data::DUMMY_CATEGORIES;
 
@@ -45,7 +44,7 @@ async fn test_get_project() {
 
         // Perform request on dummy data
         let resp = api.get_project(alpha_project_id, USER_USER_PAT).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         let body: serde_json::Value = test::read_body_json(resp).await;
 
         assert_eq!(body["id"], json!(alpha_project_id));
@@ -77,7 +76,7 @@ async fn test_get_project() {
 
         // Make the request again, this time it should be cached
         let resp = api.get_project(alpha_project_id, USER_USER_PAT).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
 
         let body: serde_json::Value = test::read_body_json(resp).await;
         assert_eq!(body["id"], json!(alpha_project_id));
@@ -85,11 +84,11 @@ async fn test_get_project() {
 
         // Request should fail on non-existent project
         let resp = api.get_project("nonexistent", USER_USER_PAT).await;
-        assert_status(&resp, StatusCode::NOT_FOUND);
+        assert_status!(&resp, StatusCode::NOT_FOUND);
 
         // Similarly, request should fail on non-authorized user, on a yet-to-be-approved or hidden project, with a 404 (hiding the existence of the project)
         let resp = api.get_project(beta_project_id, ENEMY_USER_PAT).await;
-        assert_status(&resp, StatusCode::NOT_FOUND);
+        assert_status!(&resp, StatusCode::NOT_FOUND);
     })
     .await;
 }
@@ -171,7 +170,7 @@ async fn test_add_remove_project() {
             )
             .await;
 
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
 
         // Get the project we just made, and confirm that it's correct
         let project = api
@@ -204,7 +203,7 @@ async fn test_add_remove_project() {
                 USER_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::BAD_REQUEST);
+        assert_status!(&resp, StatusCode::BAD_REQUEST);
 
         // Reusing with the same slug and a different file should fail
         let resp = api
@@ -220,7 +219,7 @@ async fn test_add_remove_project() {
                 USER_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::BAD_REQUEST);
+        assert_status!(&resp, StatusCode::BAD_REQUEST);
 
         // Different slug, different file should succeed
         let resp = api
@@ -236,7 +235,7 @@ async fn test_add_remove_project() {
                 USER_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
 
         // Get
         let project = api
@@ -246,7 +245,7 @@ async fn test_add_remove_project() {
 
         // Remove the project
         let resp = test_env.api.remove_project("demo", USER_USER_PAT).await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // Confirm that the project is gone from the cache
         let mut redis_pool = test_env.db.redis_pool.connect().await.unwrap();
@@ -269,7 +268,7 @@ async fn test_add_remove_project() {
 
         // Old slug no longer works
         let resp = api.get_project("demo", USER_USER_PAT).await;
-        assert_status(&resp, StatusCode::NOT_FOUND);
+        assert_status!(&resp, StatusCode::NOT_FOUND);
     })
     .await;
 }
@@ -293,7 +292,7 @@ pub async fn test_patch_project() {
                 ENEMY_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::UNAUTHORIZED);
+        assert_status!(&resp, StatusCode::UNAUTHORIZED);
 
         // Failure because we are setting URL fields to invalid urls.
         for url_type in ["issues", "source", "wiki", "discord"] {
@@ -308,7 +307,7 @@ pub async fn test_patch_project() {
                     USER_USER_PAT,
                 )
                 .await;
-            assert_status(&resp, StatusCode::BAD_REQUEST);
+            assert_status!(&resp, StatusCode::BAD_REQUEST);
         }
 
         // Failure because these are illegal requested statuses for a normal user.
@@ -322,7 +321,7 @@ pub async fn test_patch_project() {
                     USER_USER_PAT,
                 )
                 .await;
-            assert_status(&resp, StatusCode::BAD_REQUEST);
+            assert_status!(&resp, StatusCode::BAD_REQUEST);
         }
 
         // Failure because these should not be able to be set by a non-mod
@@ -336,7 +335,7 @@ pub async fn test_patch_project() {
                     USER_USER_PAT,
                 )
                 .await;
-            assert_status(&resp, StatusCode::UNAUTHORIZED);
+            assert_status!(&resp, StatusCode::UNAUTHORIZED);
 
             // (should work for a mod, though)
             let resp = api
@@ -348,7 +347,7 @@ pub async fn test_patch_project() {
                     MOD_USER_PAT,
                 )
                 .await;
-            assert_status(&resp, StatusCode::NO_CONTENT);
+            assert_status!(&resp, StatusCode::NO_CONTENT);
         }
 
         // Failed patch to alpha slug:
@@ -372,7 +371,7 @@ pub async fn test_patch_project() {
                     USER_USER_PAT,
                 )
                 .await;
-            assert_status(&resp, StatusCode::BAD_REQUEST);
+            assert_status!(&resp, StatusCode::BAD_REQUEST);
         }
 
         // Not allowed to directly set status, as 'beta_project_slug' (the other project) is "processing" and cannot have its status changed like this.
@@ -385,7 +384,7 @@ pub async fn test_patch_project() {
                 USER_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::UNAUTHORIZED);
+        assert_status!(&resp, StatusCode::UNAUTHORIZED);
 
         // Sucessful request to patch many fields.
         let resp = api
@@ -406,11 +405,11 @@ pub async fn test_patch_project() {
                 USER_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // Old slug no longer works
         let resp = api.get_project(alpha_project_slug, USER_USER_PAT).await;
-        assert_status(&resp, StatusCode::NOT_FOUND);
+        assert_status!(&resp, StatusCode::NOT_FOUND);
 
         // New slug does work
         let project = api.get_project_deserialized("newslug", USER_USER_PAT).await;
@@ -447,7 +446,7 @@ pub async fn test_patch_project() {
                 USER_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
         let project = api.get_project_deserialized("newslug", USER_USER_PAT).await;
         assert_eq!(project.link_urls.len(), 3);
         assert!(!project.link_urls.contains_key("issues"));
@@ -475,7 +474,7 @@ pub async fn test_patch_v3() {
                 USER_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         let project = api
             .get_project_deserialized(alpha_project_slug, USER_USER_PAT)
@@ -509,7 +508,7 @@ pub async fn test_bulk_edit_categories() {
                 ADMIN_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         let alpha_body = api
             .get_project_deserialized_common(alpha_project_id, ADMIN_USER_PAT)
@@ -552,7 +551,7 @@ pub async fn test_bulk_edit_links() {
                     ADMIN_USER_PAT,
                 )
                 .await;
-            assert_status(&resp, StatusCode::NO_CONTENT);
+            assert_status!(&resp, StatusCode::NO_CONTENT);
 
             let alpha_body = api
                 .get_project_deserialized(alpha_project_id, ADMIN_USER_PAT)
@@ -597,7 +596,7 @@ async fn delete_project_with_report() {
                 ENEMY_USER_PAT, // Enemy makes a report
             )
             .await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         let value = test::read_body_json::<serde_json::Value, _>(resp).await;
         let alpha_report_id = value["id"].as_str().unwrap();
 
@@ -608,7 +607,7 @@ async fn delete_project_with_report() {
                 ENEMY_USER_PAT, // Enemy makes a report
             )
             .await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
 
         // Do the same for beta
         let resp = api
@@ -620,13 +619,13 @@ async fn delete_project_with_report() {
                 ENEMY_USER_PAT, // Enemy makes a report
             )
             .await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         let value = test::read_body_json::<serde_json::Value, _>(resp).await;
         let beta_report_id = value["id"].as_str().unwrap();
 
         // Delete the project
         let resp = api.remove_project(alpha_project_id, USER_USER_PAT).await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // Confirm that the project is gone from the cache
         let mut redis_pool = test_env.db.redis_pool.connect().await.unwrap();
@@ -654,7 +653,7 @@ async fn delete_project_with_report() {
                 ENEMY_USER_PAT, // Enemy makes a report
             )
             .await;
-        assert_status(&resp, StatusCode::NOT_FOUND);
+        assert_status!(&resp, StatusCode::NOT_FOUND);
 
         // Confirm that report for beta still exists
         let resp = api
@@ -663,7 +662,7 @@ async fn delete_project_with_report() {
                 ENEMY_USER_PAT, // Enemy makes a report
             )
             .await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
     })
     .await;
 }
@@ -815,7 +814,7 @@ async fn permissions_patch_project_v3() {
 //                 MOD_USER_PAT,
 //             )
 //             .await;
-//         assert_status(&resp, StatusCode::NO_CONTENT);
+//         assert_status!(&resp, StatusCode::NO_CONTENT);
 
 //         // Schedule version
 //         let req_gen = |ctx: PermissionsTestContext| async move {
@@ -1112,11 +1111,11 @@ async fn permissions_manage_invites() {
                 ADMIN_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // Accept invite
         let resp = api.join_team(alpha_team_id, MOD_USER_PAT).await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // remove existing member (requires remove_member)
         let remove_member = ProjectPermissions::REMOVE_MEMBER;
@@ -1223,10 +1222,10 @@ async fn align_search_projects() {
             let project_model = api
                 .get_project(&project.id.to_string(), USER_USER_PAT)
                 .await;
-            assert_status(&project_model, StatusCode::OK);
+            assert_status!(&project_model, StatusCode::OK);
             let mut project_model: Project = test::read_body_json(project_model).await;
 
-            // Body/description is huge- don't store it in search, so it's OK if they differ here
+            // Body/description is huge- don't store it in search, so it's StatusCode::OK if they differ here
             // (Search should return "")
             project_model.description = "".into();
 
@@ -1292,9 +1291,9 @@ async fn projects_various_visibility() {
                     USER_USER_PAT,
                 )
                 .await;
-            assert_status(&resp, StatusCode::NO_CONTENT);
+            assert_status!(&resp, StatusCode::NO_CONTENT);
             let resp = env.api.join_team(zeta_team_id, FRIEND_USER_PAT).await;
-            assert_status(&resp, StatusCode::NO_CONTENT);
+            assert_status!(&resp, StatusCode::NO_CONTENT);
 
             let visible_pat_pairs = vec![
                 (&alpha_project_id_parsed, USER_USER_PAT, StatusCode::OK),
@@ -1316,7 +1315,7 @@ async fn projects_various_visibility() {
             // Tests get_project, a route that uses is_visible_project
             for (project_id, pat, expected_status) in visible_pat_pairs {
                 let resp = env.api.get_project(&project_id.to_string(), pat).await;
-                assert_status(&resp, expected_status);
+                assert_status!(&resp, expected_status);
             }
 
             // Test get_user_projects, a route that uses filter_visible_projects
@@ -1338,12 +1337,12 @@ async fn projects_various_visibility() {
                 .api
                 .organization_add_project(zeta_organization_id, alpha_project_id, USER_USER_PAT)
                 .await;
-            assert_status(&resp, StatusCode::OK);
+            assert_status!(&resp, StatusCode::OK);
             let resp = env
                 .api
                 .organization_add_project(zeta_organization_id, beta_project_id, USER_USER_PAT)
                 .await;
-            assert_status(&resp, StatusCode::OK);
+            assert_status!(&resp, StatusCode::OK);
 
             // Test get_project, a route that uses is_visible_project
             let visible_pat_pairs = vec![
@@ -1361,7 +1360,7 @@ async fn projects_various_visibility() {
 
             for (project_id, pat, expected_status) in visible_pat_pairs {
                 let resp = env.api.get_project(&project_id.to_string(), pat).await;
-                assert_status(&resp, expected_status);
+                assert_status!(&resp, expected_status);
             }
 
             // Test get_user_projects, a route that uses filter_visible_projects

--- a/tests/scopes.rs
+++ b/tests/scopes.rs
@@ -9,7 +9,6 @@ use common::api_common::models::CommonItemType;
 use common::api_common::Api;
 use common::api_v3::request_data::get_public_project_creation_data;
 use common::api_v3::ApiV3;
-use common::asserts::assert_status;
 use common::dummy_data::TestFile;
 use common::environment::{with_test_environment, with_test_environment_all, TestEnvironment};
 use common::{database::*, scopes::ScopeTest};
@@ -116,7 +115,7 @@ pub async fn notifications_scopes() {
             .api
             .add_user_to_team(alpha_team_id, FRIEND_USER_ID, None, None, USER_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // Notification get
         let read_notifications = Scopes::NOTIFICATION_READ;
@@ -189,7 +188,7 @@ pub async fn notifications_scopes() {
             .api
             .add_user_to_team(alpha_team_id, MOD_USER_ID, None, None, USER_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
         let read_notifications = Scopes::NOTIFICATION_READ;
         let req_gen = |pat: Option<String>| async move {
             api.get_user_notifications(MOD_USER_ID, pat.as_deref())
@@ -388,7 +387,7 @@ pub async fn project_version_reads_scopes() {
             .api
             .edit_version(beta_version_id, json!({ "status": "draft" }), USER_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         let req_gen = |pat: Option<String>| async move {
             api.get_version_from_hash(beta_file_hash, "sha1", pat.as_deref())

--- a/tests/teams.rs
+++ b/tests/teams.rs
@@ -1,4 +1,4 @@
-use crate::common::{api_common::ApiTeams, asserts::assert_status, database::*};
+use crate::common::{api_common::ApiTeams, database::*};
 use actix_http::StatusCode;
 use common::{
     api_v3::ApiV3,
@@ -40,7 +40,7 @@ async fn test_get_team() {
         let resp = api
             .add_user_to_team(alpha_team_id, FRIEND_USER_ID, None, None, USER_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // Team check directly
         let members = api
@@ -93,7 +93,7 @@ async fn test_get_team() {
         // An accepted member of the team should appear in the team members list
         // and should be able to see private data about the team
         let resp = api.join_team(alpha_team_id, FRIEND_USER_PAT).await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // Team check directly
         let members = api
@@ -164,7 +164,7 @@ async fn test_get_team_organization() {
         let resp = api
             .add_user_to_team(zeta_team_id, FRIEND_USER_ID, None, None, USER_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // Team check directly
         let members = api
@@ -218,7 +218,7 @@ async fn test_get_team_organization() {
         // An accepted member of the team should appear in the team members list
         // and should be able to see private data about the team
         let resp = api.join_team(zeta_team_id, FRIEND_USER_PAT).await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // Team check directly
         let members = api
@@ -273,17 +273,17 @@ async fn test_get_team_project_orgs() {
             .api
             .organization_add_project(zeta_organization_id, alpha_project_id, USER_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
 
         // Invite and add friend to zeta
         let resp = test_env
             .api
             .add_user_to_team(zeta_team_id, FRIEND_USER_ID, None, None, USER_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         let resp = test_env.api.join_team(zeta_team_id, FRIEND_USER_PAT).await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // The team members route from teams (on a project's team):
         // - the members of the project team specifically
@@ -314,21 +314,21 @@ async fn test_patch_project_team_member() {
 
         let alpha_team_id = &test_env.dummy.project_alpha.team_id;
 
-        // Edit team as admin/mod but not a part of the team should be OK
+        // Edit team as admin/mod but not a part of the team should be StatusCode::OK
         let resp = api.edit_team_member(alpha_team_id, USER_USER_ID, json!({}), ADMIN_USER_PAT).await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // As a non-owner with full permissions, attempt to edit the owner's permissions
         let resp = api.edit_team_member(alpha_team_id, USER_USER_ID, json!({
             "permissions": 0
         }), ADMIN_USER_PAT).await;
-        assert_status(&resp, StatusCode::BAD_REQUEST);
+        assert_status!(&resp, StatusCode::BAD_REQUEST);
 
         // Should not be able to edit organization permissions of a project team
         let resp = api.edit_team_member(alpha_team_id, USER_USER_ID, json!({
             "organization_permissions": 0
         }), USER_USER_PAT).await;
-        assert_status(&resp, StatusCode::BAD_REQUEST);
+        assert_status!(&resp, StatusCode::BAD_REQUEST);
 
         // Should not be able to add permissions to a user that the adding-user does not have
         // (true for both project and org)
@@ -337,24 +337,24 @@ async fn test_patch_project_team_member() {
         let resp = api.add_user_to_team(alpha_team_id, FRIEND_USER_ID,
             Some(ProjectPermissions::EDIT_MEMBER | ProjectPermissions::EDIT_BODY),
             None, USER_USER_PAT).await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // accept
         let resp = api.join_team(alpha_team_id, FRIEND_USER_PAT).await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // try to add permissions
         let resp = api.edit_team_member(alpha_team_id, FRIEND_USER_ID, json!({
             "permissions": (ProjectPermissions::EDIT_MEMBER | ProjectPermissions::EDIT_DETAILS).bits()
         }), FRIEND_USER_PAT).await; // should this be friend_user_pat
-        assert_status(&resp, StatusCode::BAD_REQUEST);
+        assert_status!(&resp, StatusCode::BAD_REQUEST);
 
         // Cannot set payouts outside of 0 and 5000
         for payout in [-1, 5001] {
             let resp = api.edit_team_member(alpha_team_id, FRIEND_USER_ID, json!({
                 "payouts_split": payout
             }), USER_USER_PAT).await;
-            assert_status(&resp, StatusCode::BAD_REQUEST);
+            assert_status!(&resp, StatusCode::BAD_REQUEST);
         }
 
         // Successful patch
@@ -364,7 +364,7 @@ async fn test_patch_project_team_member() {
                 "role": "membe2r",
                 "ordering": 5
         }), FRIEND_USER_PAT).await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // Check results
         let members = api.get_team_members_deserialized_common(alpha_team_id, FRIEND_USER_PAT).await;
@@ -383,19 +383,19 @@ async fn test_patch_organization_team_member() {
     with_test_environment(None, |test_env: TestEnvironment<ApiV3>| async move {
         let zeta_team_id = &test_env.dummy.organization_zeta.team_id;
 
-        // Edit team as admin/mod but not a part of the team should be OK
+        // Edit team as admin/mod but not a part of the team should be StatusCode::OK
         let resp = test_env
             .api
             .edit_team_member(zeta_team_id, USER_USER_ID, json!({}), ADMIN_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // As a non-owner with full permissions, attempt to edit the owner's permissions
         let resp = test_env
             .api
             .edit_team_member(zeta_team_id, USER_USER_ID, json!({ "permissions": 0 }), ADMIN_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::BAD_REQUEST);
+        assert_status!(&resp, StatusCode::BAD_REQUEST);
 
         // Should not be able to add permissions to a user that the adding-user does not have
         // (true for both project and org)
@@ -405,18 +405,18 @@ async fn test_patch_organization_team_member() {
             .api
             .add_user_to_team(zeta_team_id, FRIEND_USER_ID, None, Some(OrganizationPermissions::EDIT_MEMBER | OrganizationPermissions::EDIT_MEMBER_DEFAULT_PERMISSIONS), USER_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // accept
         let resp = test_env.api.join_team(zeta_team_id, FRIEND_USER_PAT).await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // try to add permissions- fails, as we do not have EDIT_DETAILS
         let resp = test_env
             .api
             .edit_team_member(zeta_team_id, FRIEND_USER_ID, json!({ "organization_permissions": (OrganizationPermissions::EDIT_MEMBER | OrganizationPermissions::EDIT_DETAILS).bits() }), FRIEND_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::BAD_REQUEST);
+        assert_status!(&resp, StatusCode::BAD_REQUEST);
 
         // Cannot set payouts outside of 0 and 5000
         for payout in [-1, 5001] {
@@ -424,7 +424,7 @@ async fn test_patch_organization_team_member() {
                 .api
                 .edit_team_member(zeta_team_id, FRIEND_USER_ID, json!({ "payouts_split": payout }), USER_USER_PAT)
                 .await;
-            assert_status(&resp, StatusCode::BAD_REQUEST);
+            assert_status!(&resp, StatusCode::BAD_REQUEST);
         }
 
         // Successful patch
@@ -443,7 +443,7 @@ async fn test_patch_organization_team_member() {
                 FRIEND_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // Check results
         let members = test_env
@@ -482,39 +482,39 @@ async fn transfer_ownership_v3() {
         let resp = api
             .transfer_team_ownership(alpha_team_id, FRIEND_USER_ID, USER_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::BAD_REQUEST);
+        assert_status!(&resp, StatusCode::BAD_REQUEST);
         let resp = api
             .transfer_team_ownership(alpha_team_id, FRIEND_USER_ID, FRIEND_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::UNAUTHORIZED);
+        assert_status!(&resp, StatusCode::UNAUTHORIZED);
 
         // first, invite friend
         let resp = api
             .add_user_to_team(alpha_team_id, FRIEND_USER_ID, None, None, USER_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // still cannot set friend as owner (not accepted)
         let resp = api
             .transfer_team_ownership(alpha_team_id, FRIEND_USER_ID, USER_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::BAD_REQUEST);
+        assert_status!(&resp, StatusCode::BAD_REQUEST);
 
         // accept
         let resp = api.join_team(alpha_team_id, FRIEND_USER_PAT).await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // Cannot set ourselves as owner if we are not owner
         let resp = api
             .transfer_team_ownership(alpha_team_id, FRIEND_USER_ID, FRIEND_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::UNAUTHORIZED);
+        assert_status!(&resp, StatusCode::UNAUTHORIZED);
 
         // Can set friend as owner
         let resp = api
             .transfer_team_ownership(alpha_team_id, FRIEND_USER_ID, USER_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // Check
         let members = api
@@ -543,7 +543,7 @@ async fn transfer_ownership_v3() {
         let resp = api
             .remove_from_team(alpha_team_id, FRIEND_USER_ID, USER_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::UNAUTHORIZED);
+        assert_status!(&resp, StatusCode::UNAUTHORIZED);
 
         // V3 only- confirm the owner can change their role without losing ownership
         let resp = api
@@ -556,7 +556,7 @@ async fn transfer_ownership_v3() {
                 FRIEND_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         let members = api
             .get_team_members_deserialized(alpha_team_id, USER_USER_PAT)
@@ -589,25 +589,25 @@ async fn transfer_ownership_v3() {
 
 //     // Link alpha team to zeta org
 //     let resp = api.organization_add_project(zeta_organization_id, alpha_project_id, USER_USER_PAT).await;
-//     assert_status(&resp, StatusCode::OK);
+//     assert_status!(&resp, StatusCode::OK);
 
 //     // Invite friend to zeta team with all project default permissions
 //     let resp = api.add_user_to_team(&zeta_team_id, FRIEND_USER_ID, Some(ProjectPermissions::all()), Some(OrganizationPermissions::all()), USER_USER_PAT).await;
-//     assert_status(&resp, StatusCode::NO_CONTENT);
+//     assert_status!(&resp, StatusCode::NO_CONTENT);
 
 //     // Accept invite to zeta team
 //     let resp = api.join_team(&zeta_team_id, FRIEND_USER_PAT).await;
-//     assert_status(&resp, StatusCode::NO_CONTENT);
+//     assert_status!(&resp, StatusCode::NO_CONTENT);
 
 //     // Attempt, as friend, to edit details of alpha project (should succeed, org invite accepted)
 //     let resp = api.edit_project(alpha_project_id, json!({
 //         "title": "new name"
 //     }), FRIEND_USER_PAT).await;
-//     assert_status(&resp, StatusCode::NO_CONTENT);
+//     assert_status!(&resp, StatusCode::NO_CONTENT);
 
 //     // Invite friend to alpha team with *no* project permissions
 //     let resp = api.add_user_to_team(&alpha_team_id, FRIEND_USER_ID, Some(ProjectPermissions::empty()), None, USER_USER_PAT).await;
-//     assert_status(&resp, StatusCode::NO_CONTENT);
+//     assert_status!(&resp, StatusCode::NO_CONTENT);
 
 //     // Do not accept invite to alpha team
 
@@ -615,7 +615,7 @@ async fn transfer_ownership_v3() {
 //     let resp = api.edit_project(alpha_project_id, json!({
 //         "title": "new name"
 //     }), FRIEND_USER_PAT).await;
-//     assert_status(&resp, StatusCode::UNAUTHORIZED);
+//     assert_status!(&resp, StatusCode::UNAUTHORIZED);
 
 //     test_env.cleanup().await;
 // }

--- a/tests/v2/error.rs
+++ b/tests/v2/error.rs
@@ -1,5 +1,6 @@
+use crate::assert_status;
 use crate::common::api_common::ApiProject;
-use crate::common::asserts::assert_status;
+
 use actix_http::StatusCode;
 use actix_web::test;
 use bytes::Bytes;
@@ -15,7 +16,7 @@ pub async fn error_404_empty() {
         // V2 errors should have 404 as blank body, for missing resources
         let api = &test_env.api;
         let resp = api.get_project("does-not-exist", USER_USER_PAT).await;
-        assert_status(&resp, StatusCode::NOT_FOUND);
+        assert_status!(&resp, StatusCode::NOT_FOUND);
         let body = test::read_body(resp).await;
         let empty_bytes = Bytes::from_static(b"");
         assert_eq!(body, empty_bytes);

--- a/tests/v2/project.rs
+++ b/tests/v2/project.rs
@@ -1,15 +1,17 @@
 use std::sync::Arc;
 
-use crate::common::{
-    api_common::{ApiProject, ApiVersion, AppendsOptionalPat},
-    api_v2::{request_data::get_public_project_creation_data_json, ApiV2},
-    asserts::assert_status,
-    database::{
-        generate_random_name, ADMIN_USER_PAT, FRIEND_USER_ID, FRIEND_USER_PAT, USER_USER_PAT,
+use crate::{
+    assert_status,
+    common::{
+        api_common::{ApiProject, ApiVersion, AppendsOptionalPat},
+        api_v2::{request_data::get_public_project_creation_data_json, ApiV2},
+        database::{
+            generate_random_name, ADMIN_USER_PAT, FRIEND_USER_ID, FRIEND_USER_PAT, USER_USER_PAT,
+        },
+        dummy_data::TestFile,
+        environment::{with_test_environment, TestEnvironment},
+        permissions::{PermissionsTest, PermissionsTestContext},
     },
-    dummy_data::TestFile,
-    environment::{with_test_environment, TestEnvironment},
-    permissions::{PermissionsTest, PermissionsTestContext},
 };
 use actix_http::StatusCode;
 use actix_web::test;
@@ -134,7 +136,7 @@ async fn test_add_remove_project() {
             .set_multipart(vec![json_segment.clone(), file_segment.clone()])
             .to_request();
         let resp: actix_web::dev::ServiceResponse = test_env.call(req).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
 
         // Get the project we just made, and confirm that it's correct
         let project = api.get_project_deserialized("demo", USER_USER_PAT).await;
@@ -162,7 +164,7 @@ async fn test_add_remove_project() {
             .to_request();
 
         let resp = test_env.call(req).await;
-        assert_status(&resp, StatusCode::BAD_REQUEST);
+        assert_status!(&resp, StatusCode::BAD_REQUEST);
 
         // Reusing with the same slug and a different file should fail
         let req = test::TestRequest::post()
@@ -175,7 +177,7 @@ async fn test_add_remove_project() {
             .to_request();
 
         let resp = test_env.call(req).await;
-        assert_status(&resp, StatusCode::BAD_REQUEST);
+        assert_status!(&resp, StatusCode::BAD_REQUEST);
 
         // Different slug, different file should succeed
         let req = test::TestRequest::post()
@@ -188,7 +190,7 @@ async fn test_add_remove_project() {
             .to_request();
 
         let resp = test_env.call(req).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
 
         // Get
         let project = api.get_project_deserialized("demo", USER_USER_PAT).await;
@@ -196,7 +198,7 @@ async fn test_add_remove_project() {
 
         // Remove the project
         let resp = test_env.api.remove_project("demo", USER_USER_PAT).await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // Confirm that the project is gone from the cache
         let mut redis_conn = test_env.db.redis_pool.connect().await.unwrap();
@@ -219,7 +221,7 @@ async fn test_add_remove_project() {
 
         // Old slug no longer works
         let resp = api.get_project("demo", USER_USER_PAT).await;
-        assert_status(&resp, StatusCode::NOT_FOUND);
+        assert_status!(&resp, StatusCode::NOT_FOUND);
     })
     .await;
 }
@@ -343,7 +345,7 @@ pub async fn test_patch_v2() {
                 USER_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         let project = api
             .get_project_deserialized(alpha_project_slug, USER_USER_PAT)
@@ -455,7 +457,7 @@ pub async fn test_bulk_edit_links() {
                 ADMIN_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         let alpha_body = api
             .get_project_deserialized(alpha_project_id, ADMIN_USER_PAT)
@@ -495,7 +497,7 @@ pub async fn test_bulk_edit_links() {
                 ADMIN_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         let alpha_body = api
             .get_project_deserialized(alpha_project_id, ADMIN_USER_PAT)
@@ -567,7 +569,7 @@ pub async fn test_bulk_edit_links() {
                 ADMIN_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         let alpha_body = api
             .get_project_deserialized(alpha_project_id, ADMIN_USER_PAT)

--- a/tests/v2/search.rs
+++ b/tests/v2/search.rs
@@ -1,8 +1,9 @@
+use crate::assert_status;
 use crate::common::api_common::Api;
 use crate::common::api_common::ApiProject;
 use crate::common::api_common::ApiVersion;
 use crate::common::api_v2::ApiV2;
-use crate::common::asserts::assert_status;
+
 use crate::common::database::*;
 use crate::common::dummy_data::TestFile;
 use crate::common::dummy_data::DUMMY_CATEGORIES;
@@ -55,7 +56,7 @@ async fn search_projects() {
                             MOD_USER_PAT,
                         )
                         .await;
-                    assert_status(&resp, StatusCode::NO_CONTENT);
+                    assert_status!(&resp, StatusCode::NO_CONTENT);
                     (project.id.0, id)
                 }
             };
@@ -284,7 +285,7 @@ async fn search_projects() {
 
         // Forcibly reset the search index
         let resp = api.reset_search_index().await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // Test searches
         let stream = futures::stream::iter(pairs);

--- a/tests/v2/teams.rs
+++ b/tests/v2/teams.rs
@@ -2,14 +2,17 @@ use actix_http::StatusCode;
 use labrinth::models::teams::ProjectPermissions;
 use serde_json::json;
 
-use crate::common::{
-    api_common::ApiTeams,
-    api_v2::ApiV2,
-    asserts::assert_status,
-    database::{
-        FRIEND_USER_ID, FRIEND_USER_ID_PARSED, FRIEND_USER_PAT, USER_USER_ID_PARSED, USER_USER_PAT,
+use crate::{
+    assert_status,
+    common::{
+        api_common::ApiTeams,
+        api_v2::ApiV2,
+        database::{
+            FRIEND_USER_ID, FRIEND_USER_ID_PARSED, FRIEND_USER_PAT, USER_USER_ID_PARSED,
+            USER_USER_PAT,
+        },
+        environment::{with_test_environment, TestEnvironment},
     },
-    environment::{with_test_environment, TestEnvironment},
 };
 
 // trasnfer ownership (requires being owner, etc)
@@ -25,35 +28,35 @@ async fn transfer_ownership_v2() {
         let resp = api
             .transfer_team_ownership(alpha_team_id, FRIEND_USER_ID, USER_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::BAD_REQUEST);
+        assert_status!(&resp, StatusCode::BAD_REQUEST);
 
         // first, invite friend
         let resp = api
             .add_user_to_team(alpha_team_id, FRIEND_USER_ID, None, None, USER_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // still cannot set friend as owner (not accepted)
         let resp = api
             .transfer_team_ownership(alpha_team_id, FRIEND_USER_ID, USER_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::BAD_REQUEST);
+        assert_status!(&resp, StatusCode::BAD_REQUEST);
 
         // accept
         let resp = api.join_team(alpha_team_id, FRIEND_USER_PAT).await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // Cannot set ourselves as owner if we are not owner
         let resp = api
             .transfer_team_ownership(alpha_team_id, FRIEND_USER_ID, FRIEND_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::UNAUTHORIZED);
+        assert_status!(&resp, StatusCode::UNAUTHORIZED);
 
         // Can set friend as owner
         let resp = api
             .transfer_team_ownership(alpha_team_id, FRIEND_USER_ID, USER_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         // Check
         let members = api
@@ -80,7 +83,7 @@ async fn transfer_ownership_v2() {
         let resp = api
             .remove_from_team(alpha_team_id, FRIEND_USER_ID, USER_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::UNAUTHORIZED);
+        assert_status!(&resp, StatusCode::UNAUTHORIZED);
 
         // V2 only- confirm the owner changing the role to member does nothing
         let resp = api
@@ -93,7 +96,7 @@ async fn transfer_ownership_v2() {
                 FRIEND_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
         let members = api
             .get_team_members_deserialized(alpha_team_id, USER_USER_PAT)
             .await;

--- a/tests/v2/version.rs
+++ b/tests/v2/version.rs
@@ -8,9 +8,10 @@ use labrinth::{
 };
 use serde_json::json;
 
+use crate::assert_status;
 use crate::common::api_common::{ApiProject, ApiVersion};
 use crate::common::api_v2::ApiV2;
-use crate::common::asserts::assert_status;
+
 use crate::common::dummy_data::{DummyProjectAlpha, DummyProjectBeta};
 use crate::common::environment::{with_test_environment, TestEnvironment};
 use crate::common::{
@@ -36,7 +37,7 @@ pub async fn test_patch_version() {
                 ENEMY_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::UNAUTHORIZED);
+        assert_status!(&resp, StatusCode::UNAUTHORIZED);
 
         // Failure because these are illegal requested statuses for a normal user.
         for req in ["unknown", "scheduled"] {
@@ -50,7 +51,7 @@ pub async fn test_patch_version() {
                     USER_USER_PAT,
                 )
                 .await;
-            assert_status(&resp, StatusCode::BAD_REQUEST);
+            assert_status!(&resp, StatusCode::BAD_REQUEST);
         }
 
         // Sucessful request to patch many fields.
@@ -74,7 +75,7 @@ pub async fn test_patch_version() {
                 USER_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         let version = api
             .get_version_deserialized(alpha_version_id, USER_USER_PAT)
@@ -102,7 +103,7 @@ pub async fn test_patch_version() {
                 USER_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         let version = api
             .get_version_deserialized(alpha_version_id, USER_USER_PAT)
@@ -119,7 +120,7 @@ pub async fn test_patch_version() {
                 USER_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         let version = api
             .get_version_deserialized(alpha_version_id, USER_USER_PAT)
@@ -262,12 +263,12 @@ async fn version_updates() {
                 )
                 .await;
             if success {
-                assert_status(&resp, StatusCode::OK);
+                assert_status!(&resp, StatusCode::OK);
                 let body: serde_json::Value = test::read_body_json(resp).await;
                 let id = body["id"].as_str().unwrap();
                 assert_eq!(id, &result_id.to_string());
             } else {
-                assert_status(&resp, StatusCode::NOT_FOUND);
+                assert_status!(&resp, StatusCode::NOT_FOUND);
             }
 
             // update_files

--- a/tests/version.rs
+++ b/tests/version.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use crate::common::api_common::ApiVersion;
 use crate::common::database::*;
 use crate::common::dummy_data::{DummyProjectAlpha, DummyProjectBeta, TestFile};
-use crate::common::{asserts::assert_status, get_json_val_str};
+use crate::common::get_json_val_str;
 use actix_http::StatusCode;
 use actix_web::test;
 use common::api_v3::ApiV3;
@@ -61,7 +61,7 @@ async fn test_get_version() {
 
         // Request should fail on non-existent version
         let resp = api.get_version("false", USER_USER_PAT).await;
-        assert_status(&resp, StatusCode::NOT_FOUND);
+        assert_status!(&resp, StatusCode::NOT_FOUND);
 
         // Similarly, request should fail on non-authorized user, on a yet-to-be-approved or hidden project, with a 404 (hiding the existence of the project)
         // TODO: beta version should already be draft in dummy data, but theres a bug in finding it that
@@ -74,9 +74,9 @@ async fn test_get_version() {
         )
         .await;
         let resp = api.get_version(beta_version_id, USER_USER_PAT).await;
-        assert_status(&resp, StatusCode::OK);
+        assert_status!(&resp, StatusCode::OK);
         let resp = api.get_version(beta_version_id, ENEMY_USER_PAT).await;
-        assert_status(&resp, StatusCode::NOT_FOUND);
+        assert_status!(&resp, StatusCode::NOT_FOUND);
     })
     .await;
 }
@@ -219,12 +219,12 @@ async fn version_updates() {
                     )
                     .await;
                 if success {
-                    assert_status(&resp, StatusCode::OK);
+                    assert_status!(&resp, StatusCode::OK);
                     let body: serde_json::Value = test::read_body_json(resp).await;
                     let id = body["id"].as_str().unwrap();
                     assert_eq!(id, &result_id.to_string());
                 } else {
-                    assert_status(&resp, StatusCode::NOT_FOUND);
+                    assert_status!(&resp, StatusCode::NOT_FOUND);
                 }
 
                 // update_files
@@ -405,7 +405,7 @@ pub async fn test_patch_version() {
                 ENEMY_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::UNAUTHORIZED);
+        assert_status!(&resp, StatusCode::UNAUTHORIZED);
 
         // Failure because these are illegal requested statuses for a normal user.
         for req in ["unknown", "scheduled"] {
@@ -419,7 +419,7 @@ pub async fn test_patch_version() {
                     USER_USER_PAT,
                 )
                 .await;
-            assert_status(&resp, StatusCode::BAD_REQUEST);
+            assert_status!(&resp, StatusCode::BAD_REQUEST);
         }
 
         // Sucessful request to patch many fields.
@@ -447,7 +447,7 @@ pub async fn test_patch_version() {
                 USER_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         let version = api
             .get_version_deserialized_common(alpha_version_id, USER_USER_PAT)
@@ -483,7 +483,7 @@ pub async fn test_patch_version() {
                 USER_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         let version = api
             .get_version_deserialized_common(alpha_version_id, USER_USER_PAT)
@@ -499,7 +499,7 @@ pub async fn test_patch_version() {
                 USER_USER_PAT,
             )
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         let version = api
             .get_version_deserialized_common(alpha_version_id, USER_USER_PAT)
@@ -571,7 +571,7 @@ async fn edit_version_ordering_works() {
             .api
             .edit_version_ordering(&alpha_version_id, Some(10), USER_USER_PAT)
             .await;
-        assert_status(&resp, StatusCode::NO_CONTENT);
+        assert_status!(&resp, StatusCode::NO_CONTENT);
 
         let versions = env
             .api


### PR DESCRIPTION
This:
- keeps consistency with assert_eq!, assert!, etc
- More importantly, the stacktrace generated by a failing test now correctly points to the right line _calling_ the assertion, rather than the assert_eq! contained within the assert_status function, making it a little bit easier

