### PR TITLE
Fixes modpacks losing loader data on modification

### DIFF
--- a/tests/search.rs
+++ b/tests/search.rs
@@ -106,7 +106,7 @@ async fn search_projects() {
                     found_project_ids.sort();
                     println!("Facets: {:?}", facets);
                     assert_eq!(found_project_ids, expected_project_ids);
-                    assert_eq!(num_hits, expected_project_ids.len() as usize);
+                    assert_eq!(num_hits, { expected_project_ids.len() });
                 }
             })
             .await;


### PR DESCRIPTION
EDIT version route in v2 not correctly identifying that loaders should be modified to accomodate the new mrpack backend (for modpacks specifically).
Does not retroactively fix ones modified this way- though easily fixable manually. 