### PR TITLE
Ignore spaces when parsing facets

### DIFF
--- a/src/routes/v2/projects.rs
+++ b/src/routes/v2/projects.rs
@@ -152,6 +152,7 @@ fn parse_facet(facet: &String) -> Option<(String, String, String)> {
                 val.push_str(&iterator.collect::<String>());
                 return Some((key, operator, val));
             }
+            ' ' => continue,
             _ => key.push(char),
         }
     }


### PR DESCRIPTION
In #845 I introduced a method to parse facets which is used to replace renamed facets for backwards compatibility.
After it was merged, I noticed that you can have spaces between the facet name and the operator.

When you use these spaces, the replacement code does not work, because the space is parsed into the facet type.
This is also used in the examples in the documentation.

In this PR, I added a case to the match statement that ignores spaces while parsing the facet type.
Spaces in the facet value are still ignored, but that should not matter since we don't modify these either way.

Example request that causes this problem but worked before: https://api.modrinth.com/v2/search?facets=[[%22project_type%20:%20mod%22]]